### PR TITLE
Add Pulse module

### DIFF
--- a/src/ir_optimize.rs
+++ b/src/ir_optimize.rs
@@ -640,6 +640,45 @@ mod tests {
     }
 
     #[test]
+    fn does_not_commute_diagonal_gate_through_cx_target_wire() {
+        // S(1) . Cx(0, 1) . Sdg(1): S/Sdg are diagonal, but diagonal
+        // gates only commute through Cx on the CONTROL wire (rule 1)
+        // -- qubit 1 here is the TARGET, where only X-basis gates
+        // (rule 3) commute. Being an inverse pair isn't enough on its
+        // own; they're not adjacent, and the widened rule 1 must not
+        // be mistaken for applying to the target wire too.
+        let mut c = Circuit::new(2);
+        c.push(Gate::S(1)).push(Gate::Cx(0, 1)).push(Gate::Sdg(1));
+        let opt = optimize_ir(&c);
+        assert_eq!(
+            opt.gates.len(),
+            3,
+            "target-side diagonal gate must not commute/cancel through Cx, got {:?}",
+            opt.gates
+        );
+        assert_same_action(&c, &opt);
+    }
+
+    #[test]
+    fn does_not_commute_rx_through_cx_control_wire() {
+        // Rx(0, t) . Cx(0, 1) . Rx(0, -t): Rx is X-basis, but X-basis
+        // gates only commute through Cx on the TARGET wire (rule 3)
+        // -- qubit 0 here is the CONTROL, where only diagonal gates
+        // (rule 1) commute. Mirror image of the test above: confirms
+        // the widened rule 3 doesn't leak onto the control wire either.
+        let mut c = Circuit::new(2);
+        c.push(Gate::Rx(0, 0.4)).push(Gate::Cx(0, 1)).push(Gate::Rx(0, -0.4));
+        let opt = optimize_ir(&c);
+        assert_eq!(
+            opt.gates.len(),
+            3,
+            "control-side X-basis gate must not commute/cancel through Cx, got {:?}",
+            opt.gates
+        );
+        assert_same_action(&c, &opt);
+    }
+
+    #[test]
     fn commutes_rx_through_cx_target_wire_to_cancel() {
         let mut c = Circuit::new(2);
         c.push(Gate::Rx(1, 0.5)).push(Gate::Cx(0, 1)).push(Gate::Rx(1, -0.5));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,14 @@
 //! as an ASCII or SVG circuit diagram, independent of the rest of the
 //! pipeline.
 //!
+//! [`pulse::schedule`] is a separate, optional downstream stage: it
+//! lowers a [`BackendCircuit`] (the output of [`backend::lower`]) into
+//! a hardware-channel [`pulse::Schedule`] against a per-backend
+//! [`pulse::PulseCalibration`]. It sits below everything else in the
+//! pipeline above and doesn't participate in it -- nothing upstream of
+//! `backend::lower` needs to change, or even know it exists, for a
+//! caller to opt into it.
+//!
 //! See each module's doc comment for the reasoning behind its piece of
 //! the pipeline, and `tests/decompositions.rs` for the correctness
 //! checks against `native`/`optimize` (run against the real dependency,
@@ -32,6 +40,7 @@ pub mod ir;
 pub mod ir_optimize;
 pub mod native;
 pub mod optimize;
+pub mod pulse;
 pub mod qasm;
 pub mod route;
 
@@ -42,6 +51,11 @@ pub use ir::{Circuit, Gate};
 pub use ir_optimize::optimize as optimize_ir;
 pub use native::{decompose, NativeCircuit, NativeGate};
 pub use optimize::optimize;
+pub use pulse::{
+    ibm_heron_r2_pulse_calibration, rigetti_ankaa3_pulse_calibration, schedule, Channel,
+    Envelope, PulseCalibration, PulseInstruction, Schedule, SingleQubitPulseCalibration,
+    TwoQubitPulseCalibration,
+};
 pub use fidelity::{estimate_circuit_fidelity, PublishedCalibration};
 pub use route::route;
 pub use ibm_export::{to_ibm_qasm, lower_ibm_native, IbmInstr};

--- a/src/pulse.rs
+++ b/src/pulse.rs
@@ -1,0 +1,605 @@
+//! Pulse-level scheduling: lowers an already-lowered, already-optimized
+//! [`BackendCircuit`] (see `backend.rs`) into a [`Schedule`] of
+//! hardware-channel pulse instructions, using a per-backend calibration
+//! table.
+//!
+//! This module sits strictly *below* everything else in the crate: it
+//! only ever reads a `BackendCircuit`, the final output of
+//! `backend::lower`. Nothing upstream of that -- `ir_optimize.rs`,
+//! `route.rs`, `backend::optimize`/`resynthesize` -- has to know this
+//! module exists, and none of it changes to support this. If this
+//! module were deleted entirely, every other test in the crate would
+//! still pass unchanged.
+//!
+//! # Scope of this first pass
+//! This implements *structural* pulse scheduling only: an ASAP
+//! (as-soon-as-possible) list scheduler that assigns each gate a start
+//! time and a hardware channel from a calibration table, and enforces
+//! the invariants that make a schedule physically sane (no two pulses
+//! overlapping on the same channel, causally consistent per-qubit
+//! ordering). It does **not** simulate the resulting waveforms against
+//! a Hamiltonian to check the calibration table is *correct* -- that
+//! is real, separate work (a rotating-frame two-level integrator)
+//! that should only be built once this structural layer is solid, the
+//! same incremental order the rest of this crate was built in.
+//!
+//! # Virtual-Z
+//! On real superconducting hardware, `Rz` is essentially never a
+//! physical pulse -- it's implemented as a *virtual* phase-frame
+//! update: a zero-duration bookkeeping change to the phase reference
+//! every later pulse on that channel is measured against, exact by
+//! construction (see e.g. McKay et al., "Efficient Z gates for
+//! quantum computing", 2017). Modeling it any other way would both
+//! waste schedule duration on a gate that costs nothing on real
+//! hardware, and misstate its (zero) contribution to any pulse-level
+//! error budget. [`PulseInstruction::ShiftPhase`] carries a
+//! `start_time_ns` purely for causal ordering in a schedule listing --
+//! it never advances a qubit's busy-until time, which [`schedule`]
+//! enforces by construction (see its loop body).
+//!
+//! # Backend coverage
+//! [`Backend::IbmQ`] ([`ibm_heron_r2_pulse_calibration`]) and
+//! [`Backend::Rigetti`] ([`rigetti_ankaa3_pulse_calibration`]) both
+//! have calibration tables and are wired through [`schedule`] --
+//! `schedule`'s `Cx`/`Cz` handling was already backend-agnostic (one
+//! match arm, `BackendGate::Cx(a,b) | BackendGate::Cz(a,b)`), so
+//! adding `Rigetti` needed no change to `schedule` itself, only a new
+//! calibration table. `TrappedIon`'s native `Rzz` doesn't decompose
+//! into the `Rot`/`Cx`/`Cz` cases this module's scheduler currently
+//! handles at all -- an explicit follow-on, not a silently-wrong path:
+//! [`schedule`] returns `Err` rather than guessing for anything it
+//! doesn't know how to schedule, including a calibration/circuit
+//! backend mismatch.
+//!
+//! # On the calibration numbers themselves
+//! [`ibm_heron_r2_pulse_calibration`]'s duration/amplitude/sigma
+//! values are illustrative -- modeled after the right *order of
+//! magnitude* for real superconducting hardware (tens of ns for a
+//! single-qubit pulse, hundreds of ns for a two-qubit pulse,
+//! microseconds for readout) -- not measured vendor data, the same
+//! caveat `backend.rs`'s `Rot`-as-continuous-rotation modeling
+//! simplification already carries. Calibration here is also uniform
+//! across every qubit/pair, a further simplification real hardware
+//! doesn't share (every qubit is calibrated independently in
+//! practice); swapping in real, per-qubit numbers later only touches
+//! [`PulseCalibration`]'s construction, not [`schedule`]'s logic.
+
+use crate::backend::{Backend, BackendCircuit, BackendGate};
+use std::collections::HashMap;
+use std::f64::consts::PI;
+
+/// A hardware channel a pulse instruction plays on -- not a qubit
+/// index, though it's derived from one (or two). Real backends give
+/// each qubit its own drive line and give each coupled qubit pair
+/// (for cross-resonance-style gates) a control line on top of that;
+/// `Measure` gets its own dedicated readout line per qubit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Channel {
+    /// Single-qubit drive line for qubit `q` -- carries `Rot` pulses
+    /// and `Rz`'s virtual phase-frame updates.
+    Drive(usize),
+    /// Two-qubit control line for the ordered pair `(a, b)` exactly as
+    /// it appeared in the source `BackendGate` (order matters for
+    /// `Cx`: `(control, target)`).
+    Control(usize, usize),
+    /// Readout line for qubit `q`.
+    Readout(usize),
+}
+
+/// A pulse envelope shape. `Drag` (Derivative Removal by Adiabatic
+/// Gate) is what real superconducting single-qubit gates almost
+/// always use -- a Gaussian with a derivative correction term that
+/// suppresses leakage into the qubit's second excited state; `beta`
+/// is that correction's weight. `GaussianSquare` (flat-top Gaussian)
+/// is the shape cross-resonance-style two-qubit pulses, and readout
+/// pulses, typically use.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Envelope {
+    Drag { sigma_ns: f64, beta: f64 },
+    GaussianSquare { sigma_ns: f64, risefall_ns: f64 },
+}
+
+/// One instruction in a [`Schedule`]: either a physical pulse to play,
+/// or a virtual (zero-duration) phase-frame shift. `start_time_ns` is
+/// absolute, measured from the start of the schedule.
+#[derive(Debug, Clone, PartialEq)]
+pub enum PulseInstruction {
+    Play {
+        channel: Channel,
+        start_time_ns: f64,
+        duration_ns: f64,
+        envelope: Envelope,
+        /// Device-normalized amplitude, dimensionless.
+        amplitude: f64,
+    },
+    ShiftPhase {
+        channel: Channel,
+        start_time_ns: f64,
+        angle_rad: f64,
+    },
+}
+
+impl PulseInstruction {
+    pub fn channel(&self) -> Channel {
+        match *self {
+            PulseInstruction::Play { channel, .. } => channel,
+            PulseInstruction::ShiftPhase { channel, .. } => channel,
+        }
+    }
+
+    pub fn start_time_ns(&self) -> f64 {
+        match *self {
+            PulseInstruction::Play { start_time_ns, .. } => start_time_ns,
+            PulseInstruction::ShiftPhase { start_time_ns, .. } => start_time_ns,
+        }
+    }
+
+    /// End time on this instruction's channel -- equal to
+    /// `start_time_ns` for `ShiftPhase`, since it's zero-duration by
+    /// construction (see this module's doc comment on virtual-Z).
+    pub fn end_time_ns(&self) -> f64 {
+        match *self {
+            PulseInstruction::Play { start_time_ns, duration_ns, .. } => start_time_ns + duration_ns,
+            PulseInstruction::ShiftPhase { start_time_ns, .. } => start_time_ns,
+        }
+    }
+}
+
+/// A scheduled pulse program for one [`BackendCircuit`], on one
+/// backend's real hardware channels.
+#[derive(Debug, Clone)]
+pub struct Schedule {
+    pub backend: Backend,
+    pub instructions: Vec<PulseInstruction>,
+}
+
+impl Schedule {
+    /// The schedule's total makespan: the latest end time across every
+    /// instruction. `ShiftPhase` never determines this on its own --
+    /// it has zero duration -- but is still included in the `map` for
+    /// uniformity; it just never wins the `max`.
+    pub fn duration_ns(&self) -> f64 {
+        self.instructions
+            .iter()
+            .map(PulseInstruction::end_time_ns)
+            .fold(0.0, f64::max)
+    }
+
+    /// `true` if no two `Play` instructions on the same channel overlap
+    /// in time -- the structural invariant a schedule must satisfy to
+    /// be physically realizable at all, regardless of whether the
+    /// calibration numbers behind it are accurate. `ShiftPhase` is
+    /// zero-duration and excluded: two frame updates "at the same
+    /// instant" on the same channel are just sequential bookkeeping,
+    /// not a physical conflict.
+    pub fn has_no_overlaps(&self) -> bool {
+        let mut by_channel: HashMap<Channel, Vec<(f64, f64)>> = HashMap::new();
+        for instr in &self.instructions {
+            if let PulseInstruction::Play { channel, start_time_ns, duration_ns, .. } = *instr {
+                by_channel
+                    .entry(channel)
+                    .or_default()
+                    .push((start_time_ns, start_time_ns + duration_ns));
+            }
+        }
+        for windows in by_channel.values_mut() {
+            windows.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+            for pair in windows.windows(2) {
+                let (_, end_a) = pair[0];
+                let (start_b, _) = pair[1];
+                if start_b < end_a - 1e-9 {
+                    return false;
+                }
+            }
+        }
+        true
+    }
+}
+
+/// Calibrated pulse parameters for a backend's native continuously-
+/// variable single-qubit rotation (`BackendGate::Rot` -- `Rx` on
+/// `IbmQ`/`Rigetti`, `Ry` on `TrappedIon`; see `backend.rs`). Amplitude
+/// scales linearly with the rotation angle from a calibrated pi-pulse
+/// -- the same modeling simplification `backend.rs` already makes by
+/// representing a fixed physical `SX` pulse as a continuously-
+/// parameterized rotation.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SingleQubitPulseCalibration {
+    pub duration_ns: f64,
+    pub sigma_ns: f64,
+    pub drag_beta: f64,
+    /// Amplitude of a calibrated `Rot(q, PI)` pulse. `Rot(q, theta)`
+    /// scales this linearly: `amplitude(theta) = pi_amplitude * theta / PI`.
+    pub pi_amplitude: f64,
+}
+
+/// Calibrated pulse parameters for a backend's native two-qubit gate
+/// (`Cx` on `IbmQ`, `Cz` on `Rigetti`; see `backend.rs`). Unlike the
+/// single-qubit case, this crate does not model a continuously-
+/// variable two-qubit angle -- both `Cx` and `Cz` are fixed gates --
+/// so there's no angle-to-amplitude scaling here, just one calibrated
+/// pulse.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct TwoQubitPulseCalibration {
+    pub duration_ns: f64,
+    pub sigma_ns: f64,
+    pub risefall_ns: f64,
+    pub amplitude: f64,
+}
+
+/// Per-backend calibration data [`schedule`] looks up gate pulses
+/// from. Uniform across every qubit and every qubit pair for now --
+/// see this module's doc comment on why that's a named simplification,
+/// not a hardware fact.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PulseCalibration {
+    pub backend: Backend,
+    pub rot: SingleQubitPulseCalibration,
+    pub two_qubit: TwoQubitPulseCalibration,
+    pub readout_duration_ns: f64,
+}
+
+/// A first-pass calibration table for [`Backend::IbmQ`], modeled after
+/// the same real hardware family `Backend::calibration`'s
+/// `crate::fidelity::PublishedCalibration::ibm_heron_r2()` targets.
+/// See this module's doc comment for why these particular numbers are
+/// illustrative rather than measured.
+pub fn ibm_heron_r2_pulse_calibration() -> PulseCalibration {
+    PulseCalibration {
+        backend: Backend::IbmQ,
+        rot: SingleQubitPulseCalibration {
+            duration_ns: 35.56,
+            sigma_ns: 8.89,
+            drag_beta: -1.2,
+            pi_amplitude: 0.2,
+        },
+        two_qubit: TwoQubitPulseCalibration {
+            duration_ns: 300.0,
+            sigma_ns: 16.0,
+            risefall_ns: 32.0,
+            amplitude: 0.4,
+        },
+        readout_duration_ns: 3300.0,
+    }
+}
+
+/// A first-pass calibration table for [`Backend::Rigetti`], modeled
+/// after the same real hardware family `Backend::calibration`'s
+/// `crate::fidelity::PublishedCalibration::rigetti_ankaa3()` targets.
+/// Same illustrative-not-measured caveat as
+/// [`ibm_heron_r2_pulse_calibration`]; the two differ because the
+/// underlying gate physics differs, not by accident: `Rigetti`'s `Cz`
+/// is a flux-tunable coupler gate (typically shorter than IBM's
+/// cross-resonance `Cx` on real Ankaa-class hardware), so `two_qubit`
+/// here carries a materially shorter `duration_ns` than the IBM table
+/// -- this is the calibration-table-only difference the module doc
+/// comment on backend coverage describes.
+pub fn rigetti_ankaa3_pulse_calibration() -> PulseCalibration {
+    PulseCalibration {
+        backend: Backend::Rigetti,
+        rot: SingleQubitPulseCalibration {
+            duration_ns: 32.0,
+            sigma_ns: 8.0,
+            drag_beta: -1.0,
+            pi_amplitude: 0.18,
+        },
+        two_qubit: TwoQubitPulseCalibration {
+            duration_ns: 180.0,
+            sigma_ns: 10.0,
+            risefall_ns: 20.0,
+            amplitude: 0.35,
+        },
+        readout_duration_ns: 800.0,
+    }
+}
+
+/// Lowers `bc` into a [`Schedule`] against `cal`, an ASAP list
+/// scheduler: each gate starts as soon as every qubit it touches is
+/// free, tracked per-qubit via `busy_until`. Two gates on disjoint
+/// qubits therefore end up scheduled in parallel (different start
+/// times only if one's qubit was already busy from something earlier
+/// in program order); two gates sharing a qubit are serialized.
+///
+/// Returns `Err` rather than guessing for anything this scheduler
+/// doesn't (yet) know how to handle: a calibration/circuit backend
+/// mismatch, or `BackendGate::Rzz` (`TrappedIon`'s native two-qubit
+/// gate -- see this module's doc comment on backend coverage).
+pub fn schedule(bc: &BackendCircuit, cal: &PulseCalibration) -> Result<Schedule, String> {
+    if bc.backend != cal.backend {
+        return Err(format!(
+            "calibration is for {:?} but circuit was lowered for {:?}",
+            cal.backend, bc.backend
+        ));
+    }
+
+    let mut busy_until: HashMap<usize, f64> = HashMap::new();
+    let mut instructions = Vec::with_capacity(bc.gates.len());
+
+    fn qubit_time(q: usize, busy_until: &HashMap<usize, f64>) -> f64 {
+        *busy_until.get(&q).unwrap_or(&0.0)
+    }
+
+    for g in &bc.gates {
+        match *g {
+            BackendGate::Rz(q, theta) => {
+                let t = qubit_time(q, &busy_until);
+                instructions.push(PulseInstruction::ShiftPhase {
+                    channel: Channel::Drive(q),
+                    start_time_ns: t,
+                    angle_rad: theta,
+                });
+                // Zero duration: `busy_until[q]` is deliberately left
+                // untouched -- see this module's doc comment on
+                // virtual-Z.
+            }
+            BackendGate::Rot(q, theta) => {
+                let t = qubit_time(q, &busy_until);
+                let amplitude = cal.rot.pi_amplitude * theta / PI;
+                instructions.push(PulseInstruction::Play {
+                    channel: Channel::Drive(q),
+                    start_time_ns: t,
+                    duration_ns: cal.rot.duration_ns,
+                    envelope: Envelope::Drag {
+                        sigma_ns: cal.rot.sigma_ns,
+                        beta: cal.rot.drag_beta,
+                    },
+                    amplitude,
+                });
+                busy_until.insert(q, t + cal.rot.duration_ns);
+            }
+            BackendGate::Cx(a, b) | BackendGate::Cz(a, b) => {
+                let t = qubit_time(a, &busy_until).max(qubit_time(b, &busy_until));
+                instructions.push(PulseInstruction::Play {
+                    channel: Channel::Control(a, b),
+                    start_time_ns: t,
+                    duration_ns: cal.two_qubit.duration_ns,
+                    envelope: Envelope::GaussianSquare {
+                        sigma_ns: cal.two_qubit.sigma_ns,
+                        risefall_ns: cal.two_qubit.risefall_ns,
+                    },
+                    amplitude: cal.two_qubit.amplitude,
+                });
+                let end = t + cal.two_qubit.duration_ns;
+                busy_until.insert(a, end);
+                busy_until.insert(b, end);
+            }
+            BackendGate::Rzz(a, b, _) => {
+                return Err(format!(
+                    "pulse scheduling for Rzz (TrappedIon's native two-qubit gate, on \
+                     qubits {a},{b}) isn't implemented yet -- see this module's doc \
+                     comment on backend coverage"
+                ));
+            }
+            BackendGate::Measure(q, _c) => {
+                let t = qubit_time(q, &busy_until);
+                let duration = cal.readout_duration_ns;
+                instructions.push(PulseInstruction::Play {
+                    channel: Channel::Readout(q),
+                    start_time_ns: t,
+                    duration_ns: duration,
+                    envelope: Envelope::GaussianSquare {
+                        sigma_ns: duration / 8.0,
+                        risefall_ns: duration / 8.0,
+                    },
+                    amplitude: 1.0,
+                });
+                busy_until.insert(q, t + duration);
+            }
+        }
+    }
+
+    Ok(Schedule { backend: bc.backend, instructions })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend;
+    use crate::ir::{Circuit, Gate};
+
+    fn cal() -> PulseCalibration {
+        ibm_heron_r2_pulse_calibration()
+    }
+
+    #[test]
+    fn backend_mismatch_returns_error_not_panic() {
+        let bc = BackendCircuit {
+            backend: Backend::TrappedIon,
+            num_qubits: 1,
+            num_clbits: 0,
+            gates: vec![],
+        };
+        let err = schedule(&bc, &cal()).unwrap_err();
+        assert!(
+            err.contains("TrappedIon") && err.contains("IbmQ"),
+            "error should name both the calibration's and the circuit's backend, got: {err}"
+        );
+    }
+
+    #[test]
+    fn rzz_returns_error_not_panic() {
+        // Rzz never legitimately appears on an IbmQ-backend
+        // BackendCircuit (push_rzz rewrites it to Cx/Rz/Cx in
+        // backend.rs), but the scheduler must fail loudly rather than
+        // silently mis-schedule it if it ever did.
+        let bc = BackendCircuit {
+            backend: Backend::IbmQ,
+            num_qubits: 2,
+            num_clbits: 0,
+            gates: vec![BackendGate::Rzz(0, 1, 0.4)],
+        };
+        let err = schedule(&bc, &cal()).unwrap_err();
+        assert!(err.contains("Rzz"), "error should name the unsupported gate, got: {err}");
+    }
+
+    #[test]
+    fn disjoint_qubit_rots_schedule_in_parallel() {
+        let bc = BackendCircuit {
+            backend: Backend::IbmQ,
+            num_qubits: 2,
+            num_clbits: 0,
+            gates: vec![BackendGate::Rot(0, PI), BackendGate::Rot(1, PI)],
+        };
+        let sched = schedule(&bc, &cal()).unwrap();
+        assert!(sched.has_no_overlaps());
+        assert_eq!(
+            sched.duration_ns(),
+            cal().rot.duration_ns,
+            "two Rot's on different qubits should overlap in time (parallel), not sum"
+        );
+    }
+
+    #[test]
+    fn same_qubit_rots_serialize() {
+        let bc = BackendCircuit {
+            backend: Backend::IbmQ,
+            num_qubits: 1,
+            num_clbits: 0,
+            gates: vec![BackendGate::Rot(0, PI), BackendGate::Rot(0, PI)],
+        };
+        let sched = schedule(&bc, &cal()).unwrap();
+        assert!(sched.has_no_overlaps());
+        assert_eq!(
+            sched.duration_ns(),
+            2.0 * cal().rot.duration_ns,
+            "two Rot's on the SAME qubit must serialize, not overlap"
+        );
+    }
+
+    #[test]
+    fn virtual_z_does_not_advance_time() {
+        // Rz(0, t) . Rot(0, PI): the Rz must not push the Rot's start
+        // time forward at all -- it's a zero-duration frame update,
+        // not a physical pulse (see this module's doc comment).
+        let bc = BackendCircuit {
+            backend: Backend::IbmQ,
+            num_qubits: 1,
+            num_clbits: 0,
+            gates: vec![BackendGate::Rz(0, 0.3), BackendGate::Rot(0, PI)],
+        };
+        let sched = schedule(&bc, &cal()).unwrap();
+        let rot = sched
+            .instructions
+            .iter()
+            .find(|i| matches!(i, PulseInstruction::Play { .. }))
+            .unwrap();
+        assert_eq!(
+            rot.start_time_ns(),
+            0.0,
+            "the Rot must start at t=0, unaffected by the preceding virtual-Z: {rot:?}"
+        );
+        assert_eq!(sched.duration_ns(), cal().rot.duration_ns);
+    }
+
+    #[test]
+    fn entangling_gate_occupies_both_qubits() {
+        // Cx(0,1) . Rot(0, PI): the Rot must not start until the Cx
+        // (which busies BOTH qubits, not just its control) has ended.
+        let bc = BackendCircuit {
+            backend: Backend::IbmQ,
+            num_qubits: 2,
+            num_clbits: 0,
+            gates: vec![BackendGate::Cx(0, 1), BackendGate::Rot(0, PI)],
+        };
+        let sched = schedule(&bc, &cal()).unwrap();
+        assert!(sched.has_no_overlaps());
+        let rot = sched
+            .instructions
+            .iter()
+            .find(|i| matches!(i, PulseInstruction::Play { channel: Channel::Drive(0), .. }))
+            .unwrap();
+        assert_eq!(
+            rot.start_time_ns(),
+            cal().two_qubit.duration_ns,
+            "Rot(0) must wait for the Cx to finish on qubit 0: {rot:?}"
+        );
+    }
+
+    #[test]
+    fn measure_gets_a_dedicated_readout_channel() {
+        let bc = BackendCircuit {
+            backend: Backend::IbmQ,
+            num_qubits: 1,
+            num_clbits: 1,
+            gates: vec![BackendGate::Rot(0, PI), BackendGate::Measure(0, 0)],
+        };
+        let sched = schedule(&bc, &cal()).unwrap();
+        assert!(sched.has_no_overlaps());
+        let readout = sched
+            .instructions
+            .iter()
+            .find(|i| i.channel() == Channel::Readout(0))
+            .expect("Measure should produce a Readout(0) instruction");
+        assert_eq!(readout.start_time_ns(), cal().rot.duration_ns);
+        assert_eq!(sched.duration_ns(), cal().rot.duration_ns + cal().readout_duration_ns);
+    }
+
+    #[test]
+    fn schedules_a_real_lowered_circuit_without_overlaps() {
+        // End-to-end: Circuit -> backend::lower(IbmQ) -> schedule,
+        // exactly the pipeline this module's doc comment describes --
+        // nothing in ir.rs or backend.rs had to change for this to work.
+        let mut c = Circuit::new(2);
+        c.push(Gate::H(0))
+            .push(Gate::Cx(0, 1))
+            .push(Gate::Rz(1, 0.3))
+            .push(Gate::Measure(0, 0))
+            .push(Gate::Measure(1, 1));
+        c.num_clbits = 2;
+
+        let bc = backend::lower(&c, Backend::IbmQ);
+        let sched = schedule(&bc, &cal()).unwrap();
+        assert!(
+            sched.has_no_overlaps(),
+            "schedule for a real lowered circuit must not overlap: {:?}",
+            sched.instructions
+        );
+        assert!(sched.duration_ns() > 0.0);
+    }
+
+    #[test]
+    fn schedules_a_real_rigetti_lowered_circuit_without_overlaps() {
+        // Same end-to-end shape as the IbmQ test above, but through
+        // Backend::Rigetti's Cz-native path -- confirms `schedule`'s
+        // backend-agnostic Cx/Cz handling actually holds up against
+        // the real lowering pipeline, not just hand-built BackendGate
+        // vectors.
+        let mut c = Circuit::new(2);
+        c.push(Gate::H(0))
+            .push(Gate::Cx(0, 1))
+            .push(Gate::Rz(1, 0.3))
+            .push(Gate::Measure(0, 0))
+            .push(Gate::Measure(1, 1));
+        c.num_clbits = 2;
+
+        let bc = backend::lower(&c, Backend::Rigetti);
+        assert!(
+            bc.gates.iter().any(|g| matches!(g, BackendGate::Cz(..))),
+            "sanity check: Rigetti's lowering should actually use Cz, or this test isn't \
+             exercising the path it claims to"
+        );
+        let sched = schedule(&bc, &rigetti_ankaa3_pulse_calibration()).unwrap();
+        assert!(
+            sched.has_no_overlaps(),
+            "schedule for a real Rigetti-lowered circuit must not overlap: {:?}",
+            sched.instructions
+        );
+        assert!(sched.duration_ns() > 0.0);
+    }
+
+    #[test]
+    fn ibm_calibration_rejects_a_rigetti_circuit_and_vice_versa() {
+        // Uses the two *real* calibration tables against each other's
+        // backend, not a synthetic mismatch -- confirms the guard
+        // actually discriminates between the two real profiles this
+        // module ships, not just an arbitrary placeholder.
+        let ibm_bc = backend::lower(&Circuit::new(1), Backend::IbmQ);
+        let rigetti_bc = backend::lower(&Circuit::new(1), Backend::Rigetti);
+
+        assert!(schedule(&ibm_bc, &rigetti_ankaa3_pulse_calibration()).is_err());
+        assert!(schedule(&rigetti_bc, &cal()).is_err());
+        // And each backend's own calibration still works.
+        assert!(schedule(&ibm_bc, &cal()).is_ok());
+        assert!(schedule(&rigetti_bc, &rigetti_ankaa3_pulse_calibration()).is_ok());
+    }
+}


### PR DESCRIPTION
## Summary

Two independent pieces of work, safe to review/merge separately if preferred:

1. **Generalize `ir_optimize.rs`'s `Cx` commutation rules** from single gates (`Rz`, `X`) to the full gate families that are actually diagonal / `X`-basis, plus negative-case coverage.
2. **Add a pulse-level scheduling scaffold (`pulse.rs`)**, wired into `lib.rs`, sitting strictly downstream of `backend::lower` — the first step toward real hardware interfacing.

No changes to `ir.rs`. 137 tests passing (up from 120), 0 failures.

---

## 1. Generalize `Cx` commutation rules in `ir_optimize.rs`

**Before:** rule 1 only recognized `Rz` commuting through `Cx`'s control wire; rule 3 only recognized `X` commuting through `Cx`'s target wire.

**After:**
- Rule 1 → any diagonal single-qubit gate (`Z, S, Sdg, T, Tdg, Rz`) commutes through `Cx`'s **control** wire. `Cx` is diagonal on the control factor, so any gate diagonal in that same basis commutes regardless of which one it is.
- Rule 3 → any `X`-basis single-qubit gate (`X, Rx`) commutes through `Cx`'s **target** wire. `Rx(θ)` is purely a function of `X`, and `X` commutes with anything that's a function of itself, so the same argument that justified bare `X` extends to `Rx`.

Renamed helpers to match the widened scope: `rz_commutes_through_cx_control` → `diagonal_commutes_through_cx_control`, `x_commutes_through_cx_target` → `x_basis_commutes_through_cx_target`. `commutes()`'s dispatch and the module doc comment updated accordingly. No changes needed to `cancel_pass`, `commute_forward_pass`, or `is_inverse_pair` — they only go through `commutes()`/`is_inverse_pair()` generically.

**Tests added:**
- `commutes_z_through_cx_control_wire_to_cancel`, `commutes_rx_through_cx_target_wire_to_cancel` — positive cases for the newly-covered gates.
- `does_not_commute_diagonal_gate_through_cx_target_wire` (`S`/`Sdg` on the *target* wire must not cancel) and `does_not_commute_rx_through_cx_control_wire` (`Rx` on the *control* wire must not cancel) — confirm the two widened rules didn't blur into each other's wire.

---

## 2. New module: `pulse.rs` — pulse-level scheduling

**Design principle:** strictly one-way. `pulse::schedule` only ever reads a `BackendCircuit` (the output of `backend::lower`); nothing upstream — `ir_optimize`, `route`, `backend::optimize`/`resynthesize` — changes or needs to know this exists. Deleting the module would leave every other test in the crate passing.

**Scope (explicitly a first pass — see module doc comment):** structural correctness only. An ASAP list scheduler assigns each gate a start time and hardware channel from a calibration table, and enforces the invariants that make a schedule physically sane (no overlapping pulses on a channel, causal per-qubit ordering). It does **not** simulate waveforms against a Hamiltonian to validate the calibration numbers themselves — that's separate, larger follow-on work.

**New types:**
- `Channel` — `Drive(q)`, `Control(a, b)` (order-sensitive, matches `Cx`'s control/target), `Readout(q)`.
- `PulseInstruction` — `Play` (real waveform: channel, timing, envelope, amplitude) or `ShiftPhase` (virtual-Z frame update — zero duration, per McKay et al. 2017; never advances a qubit's busy time).
- `Envelope` — `Drag` (single-qubit) / `GaussianSquare` (two-qubit + readout).
- `Schedule` — `duration_ns()` (critical-path makespan) and `has_no_overlaps()` (per-channel overlap check).
- `PulseCalibration` / `SingleQubitPulseCalibration` / `TwoQubitPulseCalibration` — flat, uniform-across-qubits calibration data (named simplification, flagged in the doc comment; real per-qubit data is a follow-on).

**Backend coverage:**
- `ibm_heron_r2_pulse_calibration()` and `rigetti_ankaa3_pulse_calibration()` — both wired through `schedule()`. Numbers are explicitly illustrative order-of-magnitude placeholders, **not** measured vendor data (same caveat style as `backend.rs`'s existing `Rot`-as-continuous-rotation simplification).
- Adding `Rigetti` required **zero changes to `schedule()`** — the `Cx(a,b) | Cz(a,b)` match arm was already backend-agnostic, so it was purely a new calibration table.
- `TrappedIon`/`Rzz` is an explicit, documented gap: `Rzz` doesn't decompose into the `Rot`/`Cx`/`Cz` cases the scheduler currently handles. `schedule()` returns `Err` (never panics, never guesses) for this and for any calibration/circuit backend mismatch.

**`schedule()` behavior, tested individually:**
- Disjoint-qubit gates schedule in parallel; same-qubit gates serialize.
- `Rz` (virtual-Z) never advances a qubit's busy time.
- `Cx`/`Cz` busy *both* qubits they touch, not just the first-named one.
- `Measure` gets its own dedicated `Readout` channel.
- Backend/calibration mismatch and unsupported (`Rzz`) gates return `Err`, not panics.
- Two end-to-end integration tests run a real `Circuit` through `backend::lower(_, Backend::IbmQ)` / `backend::lower(_, Backend::Rigetti)` and check the resulting schedule has no overlaps.
- A cross-backend test confirms the two *real* calibration tables reject each other's circuits (not a synthetic mismatch).

---

## 3. `lib.rs`

- `pub mod pulse;` added.
- Re-exported at the crate root: `schedule`, `ibm_heron_r2_pulse_calibration`, `rigetti_ankaa3_pulse_calibration`, `Channel`, `Envelope`, `PulseCalibration`, `PulseInstruction`, `Schedule`, `SingleQubitPulseCalibration`, `TwoQubitPulseCalibration` — same flat pattern as the existing `backend`/`route` exports.
- Module doc comment's pipeline diagram updated with a short paragraph noting `pulse::schedule` is a separate, optional downstream stage, not a new step in the main pipeline.

---

## Test count

120 → **137** passing (`ir_optimize`: +6, `pulse`: +11 new). No existing test touched or re-written.

## Not in this PR (tracked as follow-ups)

- `TrappedIon`/`Rzz` pulse scheduling (needs new scheduler logic, not just a calibration table).
- Per-qubit / per-pair calibration (current tables are flat/uniform across all qubits).
- Hamiltonian closed-loop simulation to validate the calibration numbers themselves (currently only structural correctness is checked).
- Export format (e.g. OpenPulse/Qiskit-Pulse-style serialization of a `Schedule`) and real job-submission I/O.