### PR TITLE
Add classical control to the IR: Gate::If

### DIFF
--- a/examples/qiskit_benchmark.rs
+++ b/examples/qiskit_benchmark.rs
@@ -354,20 +354,28 @@ fn circuit_to_portable_qasm(c: &Circuit, name: &str) -> String {
 fn backend_depth(c: &BackendCircuit) -> usize {
     let mut last_layer = vec![0usize; c.num_qubits];
     for gate in &c.gates {
-        let qs: Vec<usize> = match *gate {
-            BackendGate::Rz(q, _) | BackendGate::Rot(q, _) | BackendGate::Measure(q, _) => {
-                vec![q]
-            }
-            BackendGate::Cx(a, b) | BackendGate::Cz(a, b) | BackendGate::Rzz(a, b, _) => {
-                vec![a, b]
-            }
-        };
+        let qs = backend_gate_qubits(gate);
         let layer = qs.iter().map(|&q| last_layer[q]).max().unwrap_or(0) + 1;
         for q in qs {
             last_layer[q] = layer;
         }
     }
     last_layer.into_iter().max().unwrap_or(0)
+}
+
+/// The qubit(s) a `BackendGate` touches. `If` delegates to `inner` --
+/// a conditioned gate occupies exactly the wire(s) its inner gate
+/// does, same as `ir::Gate::If` does at the source level (see
+/// `ir::Gate::qubits`'s doc comment in the crate itself). Written
+/// locally rather than calling the crate's own `BackendGate::qubits`
+/// helper, since that one is `pub(crate)` and not visible from an
+/// example binary.
+fn backend_gate_qubits(gate: &BackendGate) -> Vec<usize> {
+    match gate {
+        BackendGate::Rz(q, _) | BackendGate::Rot(q, _) | BackendGate::Measure(q, _) => vec![*q],
+        BackendGate::Cx(a, b) | BackendGate::Cz(a, b) | BackendGate::Rzz(a, b, _) => vec![*a, *b],
+        BackendGate::If(_, _, inner) => backend_gate_qubits(inner),
+    }
 }
 
 fn export_coupling_map(coupling: &CouplingMap, path: &str) {

--- a/examples/quantum_teleportation.rs
+++ b/examples/quantum_teleportation.rs
@@ -28,9 +28,10 @@
 //!
 //! ## How this differs from a toy simulation
 //!
-//! Two things distinguish this from just calling `sirraya_qutub`
+//! Three things distinguish this from just calling `sirraya_qutub`
 //! directly (see that crate's own `examples/teleportation.rs`, which
-//! this follows for the measurement/correction/verification structure):
+//! this follows for the overall measurement/correction/verification
+//! shape):
 //!
 //! 1. **The entangling half of the circuit goes through the real
 //!    pipeline** -- `ir_optimize::optimize`, `route::route_best`
@@ -44,34 +45,45 @@
 //!    Bloch-vector calculation, across six different input states and
 //!    many repeated trials per state -- not asserted once for a single
 //!    hardcoded case.
+//! 3. **Bob's correction is a real, compiled part of the circuit**,
+//!    not something applied by hand after execution -- see the next
+//!    section for what changed and why.
 //!
-//! **One honest architectural note.** `ir::Circuit`/`Gate` has no
-//! classical-control construct today -- `Gate::Measure` writes a
-//! classical bit, but there's no "apply this gate only if that bit is
-//! 1" gate. That's a real, open gap (in the same spirit as
-//! architecture.md's own "what's finished vs. open" sections), not
-//! something this example works around silently. So the classically-
-//! conditioned half of the protocol -- the measurement and the
-//! resulting correction -- is applied directly against the
-//! `QuantumRegister` `emit::run` returns, via `measure_single_qubit`
-//! and `apply_pauli_x`/`apply_pauli_z`, exactly like
-//! `sirraya_qutub`'s own reference example does. This mirrors how real
-//! hardware actually splits the problem: static gate compilation
-//! (what this crate's pipeline does) is a separate concern from
-//! real-time classical feed-forward control electronics (what this
-//! step stands in for) -- it is not a workaround, it's the same
-//! division of labor real teleportation hardware uses.
+//! **Real classical control, not a workaround.** Earlier revisions of
+//! this example applied Bob's correction directly against the
+//! `QuantumRegister` `emit::run` returned, via `measure_single_qubit`
+//! and `apply_pauli_x`/`apply_pauli_z`, because `ir::Circuit`/`Gate`
+//! had no classical-control construct -- `Gate::Measure` could write a
+//! classical bit, but there was no "apply this gate only if that bit
+//! is 1" gate. That gap is now closed: [`Gate::If`] exists,
+//! `native::decompose_gate`/`backend::lower` carry a condition all the
+//! way through native decomposition and backend lowering (splitting it
+//! across every physical gate a multi-gate `inner` produces), and
+//! `emit::run_with_measurement`/`emit::run_backend_with_measurement`
+//! actually evaluate it against the classical bits a preceding
+//! `Measure` wrote. So the *entire* protocol -- entangling half, both
+//! of Alice's measurements, and both halves of Bob's correction -- is
+//! now one compiled [`Circuit`] (see [`full_teleportation_circuit`]),
+//! run through exactly the same `ir_optimize::optimize` -> `decompose`
+//! -> `emit::run_with_measurement` pipeline (or, for the noisy run,
+//! also through `route::route_best` and `backend::lower`) as every
+//! other gate in this example already was -- not a special case
+//! bolted on after the fact.
 //!
-//! **Why the routed circuit's qubit indices are safe to use directly
-//! after execution.** `route::route`, `route_lookahead`, `route_sabre`,
-//! and `route_qft` -- everything `route_best` can return -- all call
+//! **Why the routed circuit's qubit indices are still safe to use
+//! directly.** `route::route`, `route_lookahead`, `route_sabre`, and
+//! `route_qft` -- everything `route_best` can return -- all call
 //! `restore_identity_mapping` before returning (see `route.rs`'s own
 //! module doc). So physical qubit `i` in the circuit `route_best`
 //! hands back always means logical qubit `i` again by the time it's
-//! done, which is what makes it safe to call
-//! `register.measure_single_qubit(0)` / `(1)` and correct qubit `2`
-//! directly after running a *routed* circuit, without separately
-//! tracking a logical/physical remapping ourselves.
+//! done. That's what makes it safe to write `Gate::If(1, true,
+//! Box::new(Gate::X(2)))` against *logical* qubit 2 in
+//! [`full_teleportation_circuit`] below and trust that it still means
+//! Bob's qubit after `NoisyBackendExecutor` routes the whole circuit
+//! through a real coupling map -- the same guarantee that used to
+//! justify reading qubit 2 straight off the register after execution
+//! now equally justifies embedding a reference to it inside the
+//! circuit itself.
 //!
 //! Run with:
 //!
@@ -164,6 +176,31 @@ fn teleportation_entangling_circuit(prep: fn(&mut Circuit, usize)) -> Circuit {
     c
 }
 
+/// The complete protocol as a single compiled `Circuit`: the unitary
+/// entangling half above, followed by Alice's two measurements and
+/// Bob's classically-conditioned correction, all as real `Gate`s.
+/// Classical bit layout: clbit 0 holds q0's outcome (m0), clbit 1
+/// holds q1's outcome (m1) -- matching the two return values
+/// `run_teleportation_trial` reports.
+///
+/// **Derivation of the correction.** Tracking the state algebraically
+/// through the `Cx`+`H` above shows q2 ends up as `X^m1 Z^m0 |psi>`
+/// before correction, so applying `X` (conditioned on m1) then `Z`
+/// (conditioned on m0) inverts exactly that -- same convention
+/// `sirraya_qutub::examples::teleportation` uses, now expressed as two
+/// `Gate::If`s instead of two hand-written `if` statements around
+/// direct register calls (see this file's own doc comment for that
+/// history).
+fn full_teleportation_circuit(prep: fn(&mut Circuit, usize)) -> Circuit {
+    let mut c = teleportation_entangling_circuit(prep);
+    c.num_clbits = 2;
+    c.push(Gate::Measure(0, 0)); // m0
+    c.push(Gate::Measure(1, 1)); // m1
+    c.push(Gate::If(1, true, Box::new(Gate::X(2)))); // X iff m1 == 1
+    c.push(Gate::If(0, true, Box::new(Gate::Z(2)))); // Z iff m0 == 1
+    c
+}
+
 /// The independent ground truth for a given prep routine: what a
 /// single qubit prepared by `prep` alone actually looks like as a
 /// density matrix, run through the same real pipeline (not
@@ -193,30 +230,47 @@ fn bloch_vector(dm: &DensityMatrix) -> (f64, f64, f64) {
 }
 
 // ---------------------------------------------------------------------
-// 2. Execution seam -- identical shape to `trotter_ising_dynamics.rs`'s
-//    `CircuitExecutor`, so the same trial logic below can run against
-//    either the ideal simulator or the noisy backend model.
+// 2. Execution seam -- same shape as `trotter_ising_dynamics.rs`'s
+//    `CircuitExecutor` (ideal vs. noisy-backend, swappable behind one
+//    trait), so the same trial logic below can run against either.
+//    `run` here returns classical outcomes alongside the register,
+//    which trotter's version has no need to -- its circuits never
+//    measure mid-circuit the way this one now genuinely does.
 // ---------------------------------------------------------------------
 
 trait CircuitExecutor {
-    fn run(&mut self, circuit: &Circuit) -> Result<QuantumRegister, String>;
+    /// Returns the final register *and* every classical outcome a
+    /// `Measure` in `circuit` wrote (indexed by clbit) -- needed now
+    /// that `circuit` itself can contain `Gate::If`, which reads those
+    /// outcomes back during execution (see `emit::run_with_measurement`).
+    fn run(&mut self, circuit: &Circuit) -> Result<(QuantumRegister, Vec<u8>), String>;
 }
 
 struct IdealExecutor;
 
 impl CircuitExecutor for IdealExecutor {
-    fn run(&mut self, circuit: &Circuit) -> Result<QuantumRegister, String> {
+    fn run(&mut self, circuit: &Circuit) -> Result<(QuantumRegister, Vec<u8>), String> {
         let optimized = ir_optimize::optimize(circuit);
         let native = decompose(&optimized);
-        emit::run(&native)
+        emit::run_with_measurement(&native)
     }
 }
 
-fn gate_qubits(gate: &Gate) -> Vec<usize> {
-    match gate {
-        Gate::H(q) | Gate::X(q) | Gate::S(q) | Gate::Rx(q, _) | Gate::Ry(q, _) | Gate::Rz(q, _) => vec![*q],
-        Gate::Cx(a, b) | Gate::Swap(a, b) => vec![*a, *b],
-        _ => vec![],
+/// Qubits [`push_pauli_kick`] should follow this gate's real hardware
+/// action with a noise event on. Simply `gate.qubits()` for almost
+/// everything -- including `Gate::If`, which now delegates to its
+/// `inner`'s own qubits, so a conditioned correction gets the same
+/// style of noise injection an unconditioned one would -- except a
+/// `Measure`, which is deliberately excluded: this simple per-gate
+/// depolarizing-kick model approximates *gate* error, and a
+/// measurement's own readout error would need its own separate model.
+/// Applying a general Pauli kick to a qubit that's already been read
+/// out doesn't correspond to anything this model is trying to capture.
+fn noise_injection_qubits(gate: &Gate) -> Vec<usize> {
+    if matches!(gate, Gate::Measure(..)) {
+        Vec::new()
+    } else {
+        gate.qubits()
     }
 }
 
@@ -257,30 +311,40 @@ impl NoisyBackendExecutor {
 }
 
 impl CircuitExecutor for NoisyBackendExecutor {
-    fn run(&mut self, circuit: &Circuit) -> Result<QuantumRegister, String> {
+    fn run(&mut self, circuit: &Circuit) -> Result<(QuantumRegister, Vec<u8>), String> {
         let routed_gates: Vec<Gate> = match self.backend.coupling_map(self.n) {
             Some(coupling) => route_best(circuit, &coupling).gates,
             None => circuit.gates.clone(),
         };
         let p_gate = self.gate_error_rate(routed_gates.len());
         let mut noisy = Circuit::new(self.n);
+        // route_best's output doesn't carry num_clbits forward the way
+        // its .gates do (only .gates is used above) -- Circuit::new
+        // defaults to 0, so this must be set explicitly or
+        // `full_teleportation_circuit`'s Measure/If gates would decompose
+        // against a NativeCircuit with nowhere to write/read a
+        // classical outcome.
+        noisy.num_clbits = circuit.num_clbits;
         for gate in &routed_gates {
             noisy.push(gate.clone());
-            for q in gate_qubits(gate) {
+            for q in noise_injection_qubits(gate) {
                 push_pauli_kick(&mut noisy, q, p_gate, &mut self.rng);
             }
         }
         let optimized = ir_optimize::optimize(&noisy);
         let native = decompose(&optimized);
-        emit::run(&native)
+        emit::run_with_measurement(&native)
     }
 }
 
 // ---------------------------------------------------------------------
-// 3. One teleportation trial: run the entangling circuit through
-//    whichever executor is given, then perform the genuinely random
-//    measurement and classical correction directly on the returned
-//    register, then verify Bob's qubit two independent ways.
+// 3. One teleportation trial: run the *complete* protocol -- entangling
+//    circuit, both measurements, and both halves of Bob's classically-
+//    conditioned correction -- as a single compiled `Circuit` through
+//    whichever executor is given, then verify Bob's qubit two
+//    independent ways. Nothing here calls the register's own
+//    measure/correct methods directly anymore -- see this file's own
+//    doc comment on `Gate::If` for what changed.
 // ---------------------------------------------------------------------
 
 /// `(m0, m1, fidelity_via_density_matrix, fidelity_via_bloch_vector)`.
@@ -294,26 +358,20 @@ fn run_teleportation_trial(
     prep: fn(&mut Circuit, usize),
     target: &DensityMatrix,
 ) -> Result<(u8, u8, f64, f64), String> {
-    let circuit = teleportation_entangling_circuit(prep);
-    let mut register = executor.run(&circuit)?;
+    let circuit = full_teleportation_circuit(prep);
+    let (register, clbits) = executor.run(&circuit)?;
 
-    // Alice's genuinely random Born-rule measurement -- real
-    // `thread_rng`-backed collapse, not a simulated/deferred stand-in.
-    let m0 = register.measure_single_qubit(0)?;
-    let m1 = register.measure_single_qubit(1)?;
+    // Genuinely random Born-rule outcomes -- real `thread_rng`-backed
+    // collapse inside `Measure`'s execution, not a simulated/deferred
+    // stand-in -- read back out of the classical bits the compiled
+    // circuit's own `Gate::Measure`s wrote, exactly the way real
+    // hardware reads a classical register after a job runs.
+    let m0 = clbits[0];
+    let m1 = clbits[1];
 
-    // Bob's classically-conditioned correction. Derivation: tracking
-    // the state algebraically through the CNOT+H above shows q2 ends
-    // up as X^m1 Z^m0 |psi> before correction, so applying X (if
-    // m1=1) then Z (if m0=1) inverts exactly that -- same convention
-    // `sirraya_qutub::examples::teleportation` uses.
-    if m1 == 1 {
-        register.apply_pauli_x(2)?;
-    }
-    if m0 == 1 {
-        register.apply_pauli_z(2)?;
-    }
-
+    // Bob's correction has already been applied *inside* `executor.run`,
+    // by the circuit's own `Gate::If`s -- nothing left to do here but
+    // read qubit 2 back out and verify it.
     let bob = register.to_density_matrix()?.partial_trace(&[2])?;
     let fidelity_dm = bob.fidelity(target)?;
 
@@ -489,10 +547,11 @@ fn main() -> Result<(), String> {
     println!("  {:?} ZNE-mitigated fidelity:        {:.2}%", best_backend, mitigated * 100.0);
     println!(
         "\nEntanglement resource: 1 Bell pair. Classical communication: 2 bits.\n\
-         Corrections applied via genuine mid-circuit measurement + classical\n\
-         conditioning against the real simulator register -- not a deferred-\n\
-         measurement approximation -- on top of this crate's real routing,\n\
-         backend-lowering, and fidelity-estimation pipeline."
+         Corrections compiled as real Gate::If classical control, executed via\n\
+         genuine mid-circuit measurement + classical conditioning inside the\n\
+         circuit itself -- not a deferred-measurement approximation, and not\n\
+         applied by hand outside the circuit -- on top of this crate's real\n\
+         routing, backend-lowering, and fidelity-estimation pipeline."
     );
     println!("{}", "=".repeat(78));
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -96,7 +96,13 @@ mod trapped_ion;
 
 pub use spec::{Backend, BackendSpec, RotAxis};
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+// NOTE: no longer `Copy` -- see `NativeGate`'s identical note; `If`'s
+// `Box<BackendGate>` field is the same kind of heap allocation that
+// can't be. `resynthesize`'s `single_qubit_matrix` (the one place in
+// this file that used to take a `BackendGate` by value and then reuse
+// the original binding afterward, which only worked via implicit
+// copy) now takes `&BackendGate` instead -- see that function.
+#[derive(Debug, Clone, PartialEq)]
 pub enum BackendGate {
     Rz(usize, f64),
     /// The backend's native continuously-variable single-qubit
@@ -115,6 +121,40 @@ pub enum BackendGate {
     /// backend -- not a unitary rewrite target, so no lowering
     /// identity in this module ever targets it.
     Measure(usize, usize),
+    /// The backend-lowered counterpart of `ir::Gate::If` /
+    /// `native::NativeGate::If`: applies `inner` iff classical bit
+    /// `clbit` holds `value`. `lower`/`lower_with_coupling` produce it
+    /// by re-expressing a conditioned native gate exactly the way an
+    /// unconditioned one would be (via `push_ry`/`push_two_qubit_zz`/
+    /// direct `Rz`), then wrapping *every* `BackendGate` that
+    /// re-expansion emitted in the same condition -- so e.g. a
+    /// conditioned `Ry` lowered to an `Rx`-native backend becomes three
+    /// separately-conditioned `BackendGate`s (`Rot(pi/2)`,
+    /// `Rz(theta)`, `Rot(-pi/2)`, see [`push_ry_via_rx`]), not one `If`
+    /// wrapping all three -- the same reasoning `NativeGate::If`'s doc
+    /// comment gives for why that's the shape execution needs.
+    /// `inner` can be either 1- or 2-qubit-shaped depending on what got
+    /// re-expressed (e.g. an `Rx`-native backend's `push_two_qubit_zz`
+    /// identity for a conditioned `Rzz` produces conditioned `Cx`s, not
+    /// conditioned `Rzz`s) -- see [`BackendGate::qubits`].
+    If(usize, bool, Box<BackendGate>),
+}
+
+impl BackendGate {
+    /// Qubit indices this gate touches -- the backend-level mirror of
+    /// `ir::Gate::qubits`, including the same `If`-delegates-to-`inner`
+    /// rule. Used by [`optimize`] and [`resynthesize`] to treat a
+    /// conditioned gate as a real event on every wire it touches, the
+    /// same way `Measure` already is (see both functions' `If` arms).
+    pub(crate) fn qubits(&self) -> Vec<usize> {
+        match *self {
+            BackendGate::Rz(q, _) | BackendGate::Rot(q, _) | BackendGate::Measure(q, _) => vec![q],
+            BackendGate::Cx(a, b) | BackendGate::Cz(a, b) | BackendGate::Rzz(a, b, _) => {
+                vec![a, b]
+            }
+            BackendGate::If(_, _, ref inner) => inner.qubits(),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -142,18 +182,25 @@ impl BackendCircuit {
     /// numbers a per-backend fidelity budget needs. `Measure` is
     /// excluded from both, for the same reason `NativeCircuit::gate_counts`
     /// excludes it: it isn't a unitary gate, so a depolarizing-error
-    /// budget shouldn't price it as one.
+    /// budget shouldn't price it as one. `If` is unwrapped and its
+    /// `inner` counted as whatever it is, same reasoning as
+    /// `NativeCircuit::gate_counts`'s own `If` handling.
     pub fn gate_counts(&self) -> (usize, usize) {
         let mut single = 0;
         let mut two = 0;
         for g in &self.gates {
-            match g {
-                BackendGate::Rz(..) | BackendGate::Rot(..) => single += 1,
-                BackendGate::Cx(..) | BackendGate::Cz(..) | BackendGate::Rzz(..) => two += 1,
-                BackendGate::Measure(..) => {}
-            }
+            count_backend_gate(g, &mut single, &mut two);
         }
         (single, two)
+    }
+}
+
+fn count_backend_gate(g: &BackendGate, single: &mut usize, two: &mut usize) {
+    match g {
+        BackendGate::Rz(..) | BackendGate::Rot(..) => *single += 1,
+        BackendGate::Cx(..) | BackendGate::Cz(..) | BackendGate::Rzz(..) => *two += 1,
+        BackendGate::Measure(..) => {}
+        BackendGate::If(_, _, inner) => count_backend_gate(inner, single, two),
     }
 }
 
@@ -258,6 +305,60 @@ pub fn lower_with_coupling_no_restore(
     lower_with_coupling_impl(circuit, backend, coupling, crate::route::route_best_no_restore)
 }
 
+/// Relabels one already-native (`{Rz, Ry, Rzz, Measure}`) gate straight
+/// into `TrappedIon`'s own `BackendGate`s, 1:1, recursing into `If`'s
+/// `inner` so a conditioned gate keeps its condition through the
+/// relabeling rather than needing its own special case at every call
+/// site. Used only by the `is_native_decompose_target` branch of
+/// [`lower_with_coupling_impl`] -- every other backend goes through
+/// [`push_native_gate_reexpressed`] instead, which does real
+/// re-expansion work this function deliberately doesn't.
+fn relabel_native_to_trapped_ion(g: &crate::native::NativeGate) -> BackendGate {
+    use crate::native::NativeGate;
+    match *g {
+        NativeGate::Rz(q, a) => BackendGate::Rz(q, a),
+        NativeGate::Ry(q, a) => BackendGate::Rot(q, a),
+        NativeGate::Rzz(a, b, t) => BackendGate::Rzz(a, b, t),
+        NativeGate::Measure(q, c) => BackendGate::Measure(q, c),
+        NativeGate::If(clbit, value, ref inner) => {
+            BackendGate::If(clbit, value, Box::new(relabel_native_to_trapped_ion(inner)))
+        }
+    }
+}
+
+/// Re-expresses one already-decomposed native gate into `bc`'s backend
+/// gate set -- exactly what the inline per-gate loop in
+/// [`lower_with_coupling_impl`]'s non-`TrappedIon` branch used to do
+/// directly for `Rz`/`Ry`/`Rzz`/`Measure`, factored out so `If` can
+/// call it recursively on `inner` and then wrap *everything* that
+/// recursive call pushed in the same classical condition. That "wrap
+/// everything" step matters because `push_ry`/`push_two_qubit_zz` can
+/// each emit more than one physical `BackendGate` for a single logical
+/// native gate (see `BackendGate::If`'s own doc comment) -- every one
+/// of them must carry the same condition, not just the first.
+fn push_native_gate_reexpressed(
+    bc: &mut BackendCircuit,
+    backend: Backend,
+    axis: RotAxis,
+    g: &crate::native::NativeGate,
+) {
+    use crate::native::NativeGate;
+    match *g {
+        NativeGate::Rz(q, a) => bc.push(BackendGate::Rz(q, a)),
+        NativeGate::Ry(q, a) => push_ry(bc, axis, q, a),
+        NativeGate::Rzz(a, b, t) => backend.push_two_qubit_zz(bc, a, b, t),
+        NativeGate::Measure(q, c) => bc.push(BackendGate::Measure(q, c)),
+        NativeGate::If(clbit, value, ref inner) => {
+            let before = bc.gates.len();
+            push_native_gate_reexpressed(bc, backend, axis, inner);
+            let produced: Vec<BackendGate> = bc.gates.split_off(before);
+            for produced_gate in produced {
+                bc.push(BackendGate::If(clbit, value, Box::new(produced_gate)));
+            }
+        }
+    }
+}
+
 fn lower_with_coupling_impl(
     circuit: &Circuit,
     backend: Backend,
@@ -285,12 +386,7 @@ fn lower_with_coupling_impl(
         // TrappedIon today) -- nothing to re-express, just relabel.
         let native = crate::native::decompose(circuit);
         for g in &native.gates {
-            bc.push(match *g {
-                crate::native::NativeGate::Rz(q, a) => BackendGate::Rz(q, a),
-                crate::native::NativeGate::Ry(q, a) => BackendGate::Rot(q, a),
-                crate::native::NativeGate::Rzz(a, b, t) => BackendGate::Rzz(a, b, t),
-                crate::native::NativeGate::Measure(q, c) => BackendGate::Measure(q, c),
-            });
+            bc.push(relabel_native_to_trapped_ion(g));
         }
         optimize(&mut bc);
     } else {
@@ -326,16 +422,7 @@ fn lower_with_coupling_impl(
                     let mut nc = crate::native::NativeCircuit::new(circuit.num_qubits);
                     crate::native::decompose_gate(&mut nc, gate);
                     for g in &nc.gates {
-                        match *g {
-                            crate::native::NativeGate::Rz(q, a) => bc.push(BackendGate::Rz(q, a)),
-                            crate::native::NativeGate::Ry(q, a) => push_ry(&mut bc, axis, q, a),
-                            crate::native::NativeGate::Rzz(a, b, t) => {
-                                backend.push_two_qubit_zz(&mut bc, a, b, t)
-                            }
-                            crate::native::NativeGate::Measure(q, c) => {
-                                bc.push(BackendGate::Measure(q, c))
-                            }
-                        }
+                        push_native_gate_reexpressed(&mut bc, backend, axis, g);
                     }
                 }
             }
@@ -410,6 +497,9 @@ pub(crate) fn push_h(bc: &mut BackendCircuit, axis: RotAxis, q: usize) {
             crate::native::NativeGate::Measure(..) => {
                 unreachable!("H never decomposes to Measure")
             }
+            crate::native::NativeGate::If(..) => {
+                unreachable!("H never decomposes to a conditioned gate")
+            }
         }
     }
 }
@@ -447,8 +537,8 @@ pub fn resynthesize(bc: &mut BackendCircuit) {
 
     let axis = bc.backend.rot_axis();
 
-    fn single_qubit_matrix(axis: RotAxis, g: BackendGate) -> Option<(usize, Mat2)> {
-        match g {
+    fn single_qubit_matrix(axis: RotAxis, g: &BackendGate) -> Option<(usize, Mat2)> {
+        match *g {
             BackendGate::Rz(q, a) => Some((q, m_rz(a))),
             BackendGate::Rot(q, a) => {
                 let m = match axis {
@@ -488,7 +578,7 @@ pub fn resynthesize(bc: &mut BackendCircuit) {
     let mut out: Vec<BackendGate> = Vec::with_capacity(bc.gates.len());
 
     for g in bc.gates.drain(..) {
-        if let Some((q, m)) = single_qubit_matrix(axis, g) {
+        if let Some((q, m)) = single_qubit_matrix(axis, &g) {
             let entry = acc.entry(q).or_insert_with(m_identity);
             *entry = matmul(m, *entry);
             continue;
@@ -509,6 +599,20 @@ pub fn resynthesize(bc: &mut BackendCircuit) {
                 // rotation accumulated for it must be emitted first,
                 // the same as for a two-qubit gate touching q.
                 flush(q, &mut acc, &mut out, axis);
+                out.push(g);
+            }
+            BackendGate::If(_, _, ref inner) => {
+                // Same treatment as Measure just above, generalized to
+                // every wire the conditioned gate touches (one or two,
+                // depending on what `inner` is -- see
+                // `BackendGate::qubits`): a real event on each of them,
+                // so any pending single-qubit rotation there must be
+                // flushed first. `ref inner` (rather than binding by
+                // value) keeps `g` itself intact for `out.push(g)`
+                // below, since `BackendGate` is no longer `Copy`.
+                for q in inner.qubits() {
+                    flush(q, &mut acc, &mut out, axis);
+                }
                 out.push(g);
             }
             BackendGate::Rz(..) | BackendGate::Rot(..) => unreachable!("handled above"),
@@ -772,6 +876,23 @@ pub fn optimize(bc: &mut BackendCircuit) {
                 invalidate_pairs_touching(&mut last_2q, q);
                 out.push(Some(g));
             }
+            BackendGate::If(_, _, ref inner) => {
+                // Same barrier treatment as Measure just above, over
+                // every wire `inner` touches (one or two -- see
+                // `BackendGate::qubits`): a conditioned gate is a real
+                // event on those wires whether or not it ends up firing
+                // at runtime, since the *pulse* is compiled statically
+                // either way (see `emit.rs`'s execution of this
+                // variant, which is what actually decides at runtime).
+                // `ref inner` keeps `g` intact for `out.push(Some(g))`,
+                // since `BackendGate` is no longer `Copy`.
+                for q in inner.qubits() {
+                    flush(q, &mut pending_rz, &mut last_rot, &mut last_2q, &mut out);
+                    last_rot.remove(&q);
+                    invalidate_pairs_touching(&mut last_2q, q);
+                }
+                out.push(Some(g));
+            }
         }
     }
 
@@ -848,6 +969,13 @@ mod tests {
                     "apply_backend_circuit: Measure execution is blocked on confirming \
                      sirraya_qutub::core::QuantumRegister's measurement API (see P0.1's \
                      definition of done) -- no test in this file exercises Measure yet."
+                ),
+                BackendGate::If(..) => panic!(
+                    "apply_backend_circuit: If execution needs the same shot-based \
+                     methodology Measure above is blocked on, plus a way to feed this \
+                     direct-simulation comparison a classical outcome to condition on -- no \
+                     test in this file exercises If yet; see emit.rs's \
+                     apply_backend_to_with_measurement for the real, tested execution path."
                 ),
             }
         }
@@ -929,6 +1057,16 @@ mod tests {
                     BackendGate::Rzz(a, b, _) => Some((a, b)),
                     BackendGate::Rz(..) | BackendGate::Rot(..) => None,
                     BackendGate::Measure(..) => None,
+                    // Recurse rather than `None`: a conditioned Cx/Cz/
+                    // Rzz (possible on a non-TrappedIon backend, see
+                    // BackendGate::If's doc comment) still needs its
+                    // adjacency checked, exactly as much as an
+                    // unconditioned one would.
+                    BackendGate::If(_, _, ref inner) => match inner.as_ref() {
+                        BackendGate::Cx(a, b) | BackendGate::Cz(a, b) => Some((*a, *b)),
+                        BackendGate::Rzz(a, b, _) => Some((*a, *b)),
+                        _ => None,
+                    },
                 };
                 if let Some((a, b)) = pair {
                     assert!(

--- a/src/diagram.rs
+++ b/src/diagram.rs
@@ -75,6 +75,46 @@ pub enum DiagramInstr {
     Measure { qubit: usize, clbit: usize },
 }
 
+/// Prefixes an already-built [`DiagramInstr`]'s display label(s) with
+/// `IF c{clbit}=={0|1}: `, for a gate that came from `Gate::If` /
+/// `NativeGate::If` / `BackendGate::If`. This crate's diagram model has
+/// no dedicated "conditional" shape -- the five variants above already
+/// cover every gate at every level (see this module's doc comment) --
+/// so a conditioned gate is drawn as exactly the same box/span/marker
+/// its unconditioned form would be, just labeled with the condition
+/// that gates it. This mirrors how vendor circuit diagrams usually
+/// render classical control in practice: an annotation on the existing
+/// box, not a new shape.
+fn prefix_instr_label(instr: DiagramInstr, clbit: usize, value: bool) -> DiagramInstr {
+    let prefix = format!("IF c{}=={}: ", clbit, value as u8);
+    match instr {
+        DiagramInstr::Single { qubit, label } => {
+            DiagramInstr::Single { qubit, label: format!("{}{}", prefix, label) }
+        }
+        DiagramInstr::Controlled { controls, target, target_label } => DiagramInstr::Controlled {
+            controls,
+            target,
+            target_label: Some(format!("{}{}", prefix, target_label.unwrap_or_default())),
+        },
+        DiagramInstr::Span { qubits, label } => {
+            DiagramInstr::Span { qubits, label: format!("{}{}", prefix, label) }
+        }
+        // `Swap` has no label slot to annotate, and `Gate::If` never
+        // actually wraps one in practice (this crate's own `if`
+        // extension -- see `qasm.rs`'s `parse_if_condition` doc
+        // comment -- always wraps exactly one gate statement, and a
+        // conditioned Swap has no real use here), but this stays a
+        // total function rather than an `unreachable!()` in case that
+        // ever changes -- the condition is silently not drawable
+        // rather than causing a panic.
+        DiagramInstr::Swap { a, b } => DiagramInstr::Swap { a, b },
+        // Never actually reachable -- `Gate::If` can't wrap `Measure`
+        // (see `Circuit::validate`) -- kept exhaustive rather than
+        // `unreachable!()` for the same reason as the `Swap` arm above.
+        DiagramInstr::Measure { qubit, clbit } => DiagramInstr::Measure { qubit, clbit },
+    }
+}
+
 impl DiagramInstr {
     /// The inclusive `(min, max)` wire range this instruction's box or
     /// connecting line visually occupies -- used both for column
@@ -125,37 +165,45 @@ fn fmt_angle(label: &str, angle: f64) -> String {
     format!("{}({:.2})", label, angle)
 }
 
+/// One source-level gate's `DiagramInstr`, factored out of
+/// [`Diagram::from_circuit`] so `Gate::If` can call it recursively on
+/// `inner` and then [`prefix_instr_label`] the result -- the same
+/// pattern `Diagram::from_native`/`from_backend` use via
+/// [`instr_for_native_gate`]/[`instr_for_backend_gate`] below.
+fn instr_for_gate(gate: &Gate) -> DiagramInstr {
+    match *gate {
+        Gate::H(q) => single(q, "H"),
+        Gate::X(q) => single(q, "X"),
+        Gate::Y(q) => single(q, "Y"),
+        Gate::Z(q) => single(q, "Z"),
+        Gate::S(q) => single(q, "S"),
+        Gate::Sdg(q) => single(q, "SDG"),
+        Gate::T(q) => single(q, "T"),
+        Gate::Tdg(q) => single(q, "TDG"),
+        Gate::Rx(q, a) => DiagramInstr::Single { qubit: q, label: fmt_angle("RX", a) },
+        Gate::Ry(q, a) => DiagramInstr::Single { qubit: q, label: fmt_angle("RY", a) },
+        Gate::Rz(q, a) => DiagramInstr::Single { qubit: q, label: fmt_angle("RZ", a) },
+        Gate::Cx(c, t) => controlled(c, t, Some("X".to_string())),
+        Gate::Cz(a, b) => controlled(a, b, None),
+        Gate::Swap(a, b) => DiagramInstr::Swap { a, b },
+        Gate::Rxx(a, b, t) => DiagramInstr::Span { qubits: (a, b), label: fmt_angle("RXX", t) },
+        Gate::Ryy(a, b, t) => DiagramInstr::Span { qubits: (a, b), label: fmt_angle("RYY", t) },
+        Gate::Rzz(a, b, t) => DiagramInstr::Span { qubits: (a, b), label: fmt_angle("RZZ", t) },
+        Gate::Cp(c, t, l) => controlled(c, t, Some(fmt_angle("P", l))),
+        Gate::Measure(q, c) => DiagramInstr::Measure { qubit: q, clbit: c },
+        Gate::If(clbit, value, ref inner) => {
+            prefix_instr_label(instr_for_gate(inner), clbit, value)
+        }
+    }
+}
+
 impl Diagram {
     /// Builds a diagram from a source-level [`Circuit`] (logical
     /// qubits, pre-routing) -- the richest of the three gate sets, so
     /// this is the only conversion that needs every [`DiagramInstr`]
     /// variant.
     pub fn from_circuit(circuit: &Circuit) -> Self {
-        let mut instrs = Vec::with_capacity(circuit.gates.len());
-        for gate in &circuit.gates {
-            let instr = match *gate {
-                Gate::H(q) => single(q, "H"),
-                Gate::X(q) => single(q, "X"),
-                Gate::Y(q) => single(q, "Y"),
-                Gate::Z(q) => single(q, "Z"),
-                Gate::S(q) => single(q, "S"),
-                Gate::Sdg(q) => single(q, "SDG"),
-                Gate::T(q) => single(q, "T"),
-                Gate::Tdg(q) => single(q, "TDG"),
-                Gate::Rx(q, a) => DiagramInstr::Single { qubit: q, label: fmt_angle("RX", a) },
-                Gate::Ry(q, a) => DiagramInstr::Single { qubit: q, label: fmt_angle("RY", a) },
-                Gate::Rz(q, a) => DiagramInstr::Single { qubit: q, label: fmt_angle("RZ", a) },
-                Gate::Cx(c, t) => controlled(c, t, Some("X".to_string())),
-                Gate::Cz(a, b) => controlled(a, b, None),
-                Gate::Swap(a, b) => DiagramInstr::Swap { a, b },
-                Gate::Rxx(a, b, t) => DiagramInstr::Span { qubits: (a, b), label: fmt_angle("RXX", t) },
-                Gate::Ryy(a, b, t) => DiagramInstr::Span { qubits: (a, b), label: fmt_angle("RYY", t) },
-                Gate::Rzz(a, b, t) => DiagramInstr::Span { qubits: (a, b), label: fmt_angle("RZZ", t) },
-                Gate::Cp(c, t, l) => controlled(c, t, Some(fmt_angle("P", l))),
-                Gate::Measure(q, c) => DiagramInstr::Measure { qubit: q, clbit: c },
-            };
-            instrs.push(instr);
-        }
+        let instrs = circuit.gates.iter().map(instr_for_gate).collect();
         Self {
             num_qubits: circuit.num_qubits,
             num_clbits: circuit.num_clbits,
@@ -168,18 +216,7 @@ impl Diagram {
     /// `{Rz, Ry, Rzz}` gate set) -- three gate kinds map to exactly
     /// three [`DiagramInstr`] shapes.
     pub fn from_native(circuit: &NativeCircuit) -> Self {
-        let mut instrs = Vec::with_capacity(circuit.gates.len());
-        for gate in &circuit.gates {
-            let instr = match *gate {
-                NativeGate::Rz(q, a) => DiagramInstr::Single { qubit: q, label: fmt_angle("RZ", a) },
-                NativeGate::Ry(q, a) => DiagramInstr::Single { qubit: q, label: fmt_angle("RY", a) },
-                NativeGate::Rzz(a, b, t) => {
-                    DiagramInstr::Span { qubits: (a, b), label: fmt_angle("RZZ", t) }
-                }
-                NativeGate::Measure(q, c) => DiagramInstr::Measure { qubit: q, clbit: c },
-            };
-            instrs.push(instr);
-        }
+        let instrs = circuit.gates.iter().map(instr_for_native_gate).collect();
         Self {
             num_qubits: circuit.num_qubits,
             num_clbits: circuit.num_clbits,
@@ -201,22 +238,11 @@ impl Diagram {
             RotAxis::Ry => "RY",
             RotAxis::Rx => "RX",
         };
-        let mut instrs = Vec::with_capacity(circuit.gates.len());
-        for gate in &circuit.gates {
-            let instr = match *gate {
-                BackendGate::Rz(q, a) => DiagramInstr::Single { qubit: q, label: fmt_angle("RZ", a) },
-                BackendGate::Rot(q, a) => {
-                    DiagramInstr::Single { qubit: q, label: fmt_angle(rot_axis, a) }
-                }
-                BackendGate::Cx(a, b) => controlled(a, b, Some("X".to_string())),
-                BackendGate::Cz(a, b) => controlled(a, b, None),
-                BackendGate::Rzz(a, b, t) => {
-                    DiagramInstr::Span { qubits: (a, b), label: fmt_angle("RZZ", t) }
-                }
-                BackendGate::Measure(q, c) => DiagramInstr::Measure { qubit: q, clbit: c },
-            };
-            instrs.push(instr);
-        }
+        let instrs = circuit
+            .gates
+            .iter()
+            .map(|g| instr_for_backend_gate(g, rot_axis))
+            .collect();
         Self {
             num_qubits: circuit.num_qubits,
             num_clbits: circuit.num_clbits,
@@ -235,6 +261,39 @@ impl Diagram {
     /// to a `.svg` file or embed inline).
     pub fn to_svg(&self) -> String {
         crate::diagram::svg::render(self)
+    }
+}
+
+/// One [`NativeCircuit`] gate's `DiagramInstr` -- see [`instr_for_gate`]
+/// for why this is factored out (the same `If`-recursion reason).
+fn instr_for_native_gate(gate: &NativeGate) -> DiagramInstr {
+    match *gate {
+        NativeGate::Rz(q, a) => DiagramInstr::Single { qubit: q, label: fmt_angle("RZ", a) },
+        NativeGate::Ry(q, a) => DiagramInstr::Single { qubit: q, label: fmt_angle("RY", a) },
+        NativeGate::Rzz(a, b, t) => DiagramInstr::Span { qubits: (a, b), label: fmt_angle("RZZ", t) },
+        NativeGate::Measure(q, c) => DiagramInstr::Measure { qubit: q, clbit: c },
+        NativeGate::If(clbit, value, ref inner) => {
+            prefix_instr_label(instr_for_native_gate(inner), clbit, value)
+        }
+    }
+}
+
+/// One [`BackendCircuit`] gate's `DiagramInstr` -- see
+/// [`instr_for_gate`] for why this is factored out. `rot_axis` is
+/// `from_backend`'s own already-resolved `"RY"`/`"RX"` label (see that
+/// function's doc comment on why `BackendGate::Rot` alone can't tell
+/// you which).
+fn instr_for_backend_gate(gate: &BackendGate, rot_axis: &str) -> DiagramInstr {
+    match *gate {
+        BackendGate::Rz(q, a) => DiagramInstr::Single { qubit: q, label: fmt_angle("RZ", a) },
+        BackendGate::Rot(q, a) => DiagramInstr::Single { qubit: q, label: fmt_angle(rot_axis, a) },
+        BackendGate::Cx(a, b) => controlled(a, b, Some("X".to_string())),
+        BackendGate::Cz(a, b) => controlled(a, b, None),
+        BackendGate::Rzz(a, b, t) => DiagramInstr::Span { qubits: (a, b), label: fmt_angle("RZZ", t) },
+        BackendGate::Measure(q, c) => DiagramInstr::Measure { qubit: q, clbit: c },
+        BackendGate::If(clbit, value, ref inner) => {
+            prefix_instr_label(instr_for_backend_gate(inner, rot_axis), clbit, value)
+        }
     }
 }
 

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -44,6 +44,14 @@ pub fn apply_to(circuit: &NativeCircuit, reg: &mut QuantumRegister) -> Result<()
                         .to_string(),
                 );
             }
+            NativeGate::If(..) => {
+                return Err(
+                    "NativeGate::If is not supported by emit::apply_to -- it must read a \
+                     classical bit that no earlier gate in this entry point has anywhere to \
+                     write; use apply_to_with_measurement (or run_with_measurement) instead"
+                        .to_string(),
+                );
+            }
         }
     }
     Ok(())
@@ -76,24 +84,84 @@ pub fn apply_to_with_measurement(
     clbits: &mut [u8],
 ) -> Result<(), String> {
     for gate in &circuit.gates {
-        match *gate {
-            NativeGate::Rz(q, angle) => reg.apply_rz(q, angle)?,
-            NativeGate::Ry(q, angle) => reg.apply_ry(q, angle)?,
-            NativeGate::Rzz(a, b, angle) => reg.apply_rzz(a, b, angle)?,
-            NativeGate::Measure(q, c) => {
-                let outcome = reg.measure_single_qubit(q)?;
-                let num_clbits = clbits.len();
-                let slot = clbits.get_mut(c).ok_or_else(|| {
-                    format!(
-                        "Measure writes classical bit {} but only {} were provided",
-                        c, num_clbits
-                    )
-                })?;
-                *slot = outcome;
+        apply_native_gate_with_measurement(gate, reg, clbits)?;
+    }
+    Ok(())
+}
+
+/// The actual per-gate execution [`apply_to_with_measurement`] and
+/// [`NativeGate::If`]'s own conditional branch below both need --
+/// factored out so `If`'s recursion into its `inner` doesn't need a
+/// second copy of the `Rz`/`Ry`/`Rzz`/`Measure` dispatch.
+fn apply_native_gate_with_measurement(
+    gate: &NativeGate,
+    reg: &mut QuantumRegister,
+    clbits: &mut [u8],
+) -> Result<(), String> {
+    match *gate {
+        NativeGate::Rz(q, angle) => reg.apply_rz(q, angle)?,
+        NativeGate::Ry(q, angle) => reg.apply_ry(q, angle)?,
+        NativeGate::Rzz(a, b, angle) => reg.apply_rzz(a, b, angle)?,
+        NativeGate::Measure(q, c) => {
+            let outcome = reg.measure_single_qubit(q)?;
+            let num_clbits = clbits.len();
+            let slot = clbits.get_mut(c).ok_or_else(|| {
+                format!(
+                    "Measure writes classical bit {} but only {} were provided",
+                    c, num_clbits
+                )
+            })?;
+            *slot = outcome;
+        }
+        NativeGate::If(clbit, value, ref inner) => {
+            // This is the real thing `examples/quantum_teleportation.rs`
+            // used to do by hand, directly against the `QuantumRegister`
+            // after `emit::run` returned -- see that example's updated
+            // doc comment for the before/after. `inner` is always a
+            // bare Rz/Ry/Rzz (never Measure or another If -- see
+            // `NativeGate::If`'s own doc comment), so this recursion
+            // bottoms out in exactly one more call.
+            let num_clbits = clbits.len();
+            let outcome = *clbits.get(clbit).ok_or_else(|| {
+                format!("If reads classical bit {} but only {} were provided", clbit, num_clbits)
+            })?;
+            if (outcome != 0) == value {
+                apply_native_gate_with_measurement(inner, reg, clbits)?;
             }
         }
     }
     Ok(())
+}
+
+/// One native gate's statement text (no trailing `;`/newline), shared
+/// by [`to_qasm`]/[`to_qasm3`] so the `rz`/`ry`/`rzz` spelling and the
+/// `If`-prefix logic live in exactly one place. `measure_stmt` renders
+/// `Measure`'s own dialect-specific spelling (arrow-style for 2.0,
+/// assignment-style for 3.0 -- the one real difference between the two
+/// emitters); everything else, including `If`, is identical between
+/// them.
+///
+/// The `if (c[N]==0|1) <stmt>` syntax this emits for `NativeGate::If`
+/// is this crate's own dialect extension, the same kind of deliberate,
+/// documented departure from the standard `qasm.rs`'s module doc
+/// already notes for `rzz`/`ryy` -- real OPENQASM 2.0's `if` conditions
+/// on a whole `creg`'s *integer value*, not one indexed bit, and QASM
+/// 3.0 has no single-statement (non-block) `if` at all. `qasm::parse`'s
+/// `parse_if_condition` is the matching reader, so this still
+/// round-trips exactly the way every other statement here does.
+fn native_gate_stmt(gate: &NativeGate, measure_stmt: &dyn Fn(usize, usize) -> String) -> String {
+    match *gate {
+        NativeGate::Rz(q, angle) => format!("rz({}) q[{}]", angle, q),
+        NativeGate::Ry(q, angle) => format!("ry({}) q[{}]", angle, q),
+        NativeGate::Rzz(a, b, angle) => format!("rzz({}) q[{}], q[{}]", angle, a, b),
+        NativeGate::Measure(q, c) => measure_stmt(q, c),
+        NativeGate::If(clbit, value, ref inner) => format!(
+            "if (c[{}]=={}) {}",
+            clbit,
+            value as u8,
+            native_gate_stmt(inner, measure_stmt)
+        ),
+    }
 }
 
 /// `sirraya_qutub`-dialect OPENQASM 2.0 text for the native circuit,
@@ -114,20 +182,12 @@ pub fn to_qasm(circuit: &NativeCircuit, circuit_name: &str) -> String {
     // Measure whose clbit index is >= num_qubits.
     out.push_str(&format!("creg c[{}];\n", circuit.num_clbits));
     out.push_str(&format!(
-        "// Circuit: {} (native gate set: rz, ry, rzz, measure)\n",
+        "// Circuit: {} (native gate set: rz, ry, rzz, measure, if)\n",
         circuit_name
     ));
     for gate in &circuit.gates {
-        match *gate {
-            NativeGate::Rz(q, angle) => out.push_str(&format!("rz({}) q[{}];\n", angle, q)),
-            NativeGate::Ry(q, angle) => out.push_str(&format!("ry({}) q[{}];\n", angle, q)),
-            NativeGate::Rzz(a, b, angle) => {
-                out.push_str(&format!("rzz({}) q[{}], q[{}];\n", angle, a, b))
-            }
-            NativeGate::Measure(q, c) => {
-                out.push_str(&format!("measure q[{}] -> c[{}];\n", q, c))
-            }
-        }
+        out.push_str(&native_gate_stmt(gate, &|q, c| format!("measure q[{}] -> c[{}]", q, c)));
+        out.push_str(";\n");
     }
     out
 }
@@ -151,20 +211,12 @@ pub fn to_qasm3(circuit: &NativeCircuit, circuit_name: &str) -> String {
     // circuit.num_qubits -- same reasoning applies here.
     out.push_str(&format!("bit[{}] c;\n", circuit.num_clbits));
     out.push_str(&format!(
-        "// Circuit: {} (native gate set: rz, ry, rzz, measure)\n",
+        "// Circuit: {} (native gate set: rz, ry, rzz, measure, if)\n",
         circuit_name
     ));
     for gate in &circuit.gates {
-        match *gate {
-            NativeGate::Rz(q, angle) => out.push_str(&format!("rz({}) q[{}];\n", angle, q)),
-            NativeGate::Ry(q, angle) => out.push_str(&format!("ry({}) q[{}];\n", angle, q)),
-            NativeGate::Rzz(a, b, angle) => {
-                out.push_str(&format!("rzz({}) q[{}], q[{}];\n", angle, a, b))
-            }
-            NativeGate::Measure(q, c) => {
-                out.push_str(&format!("c[{}] = measure q[{}];\n", c, q))
-            }
-        }
+        out.push_str(&native_gate_stmt(gate, &|q, c| format!("c[{}] = measure q[{}]", c, q)));
+        out.push_str(";\n");
     }
     out
 }
@@ -214,6 +266,15 @@ pub fn apply_backend_to(circuit: &BackendCircuit, reg: &mut QuantumRegister) -> 
                         .to_string(),
                 );
             }
+            BackendGate::If(..) => {
+                return Err(
+                    "BackendGate::If is not supported by emit::apply_backend_to -- it must \
+                     read a classical bit that no earlier gate in this entry point has \
+                     anywhere to write; use apply_backend_to_with_measurement (or \
+                     run_backend_with_measurement) instead"
+                        .to_string(),
+                );
+            }
         }
     }
     Ok(())
@@ -238,25 +299,50 @@ pub fn apply_backend_to_with_measurement(
     clbits: &mut [u8],
 ) -> Result<(), String> {
     for gate in &circuit.gates {
-        match *gate {
-            BackendGate::Rz(q, angle) => reg.apply_rz(q, angle)?,
-            BackendGate::Rot(q, angle) => match circuit.backend.rot_axis() {
-                RotAxis::Ry => reg.apply_ry(q, angle)?,
-                RotAxis::Rx => reg.apply_rx(q, angle)?,
-            },
-            BackendGate::Cx(a, b) => reg.apply_cnot(a, b)?,
-            BackendGate::Cz(a, b) => reg.apply_controlled_z(a, b)?,
-            BackendGate::Rzz(a, b, angle) => reg.apply_rzz(a, b, angle)?,
-            BackendGate::Measure(q, c) => {
-                let outcome = reg.measure_single_qubit(q)?;
-                let num_clbits = clbits.len();
-                let slot = clbits.get_mut(c).ok_or_else(|| {
-                    format!(
-                        "Measure writes classical bit {} but only {} were provided",
-                        c, num_clbits
-                    )
-                })?;
-                *slot = outcome;
+        apply_backend_gate_with_measurement(circuit, gate, reg, clbits)?;
+    }
+    Ok(())
+}
+
+/// The actual per-gate execution [`apply_backend_to_with_measurement`]
+/// and `BackendGate::If`'s own conditional branch below both need --
+/// same factoring-out as [`apply_native_gate_with_measurement`], one
+/// level up the pipeline. `circuit` is only needed for
+/// `circuit.backend.rot_axis()` (which `BackendGate::Rot` alone can't
+/// tell you -- see this module's doc comment on that variant).
+fn apply_backend_gate_with_measurement(
+    circuit: &BackendCircuit,
+    gate: &BackendGate,
+    reg: &mut QuantumRegister,
+    clbits: &mut [u8],
+) -> Result<(), String> {
+    match *gate {
+        BackendGate::Rz(q, angle) => reg.apply_rz(q, angle)?,
+        BackendGate::Rot(q, angle) => match circuit.backend.rot_axis() {
+            RotAxis::Ry => reg.apply_ry(q, angle)?,
+            RotAxis::Rx => reg.apply_rx(q, angle)?,
+        },
+        BackendGate::Cx(a, b) => reg.apply_cnot(a, b)?,
+        BackendGate::Cz(a, b) => reg.apply_controlled_z(a, b)?,
+        BackendGate::Rzz(a, b, angle) => reg.apply_rzz(a, b, angle)?,
+        BackendGate::Measure(q, c) => {
+            let outcome = reg.measure_single_qubit(q)?;
+            let num_clbits = clbits.len();
+            let slot = clbits.get_mut(c).ok_or_else(|| {
+                format!(
+                    "Measure writes classical bit {} but only {} were provided",
+                    c, num_clbits
+                )
+            })?;
+            *slot = outcome;
+        }
+        BackendGate::If(clbit, value, ref inner) => {
+            let num_clbits = clbits.len();
+            let outcome = *clbits.get(clbit).ok_or_else(|| {
+                format!("If reads classical bit {} but only {} were provided", clbit, num_clbits)
+            })?;
+            if (outcome != 0) == value {
+                apply_backend_gate_with_measurement(circuit, inner, reg, clbits)?;
             }
         }
     }
@@ -316,5 +402,42 @@ mod qasm3_emit_tests {
         assert!(text.contains("c[0] = measure q[0];"));
         assert!(!text.contains("qreg"));
         assert!(!text.contains("->"));
+    }
+
+    fn conditioned_circuit() -> NativeCircuit {
+        // The teleportation shape in miniature: measure, then a
+        // conditioned correction.
+        let mut nc = NativeCircuit::new(2);
+        nc.num_clbits = 1;
+        nc.push(NativeGate::Measure(0, 0));
+        nc.push(NativeGate::If(0, true, Box::new(NativeGate::Rz(1, 0.5))));
+        nc
+    }
+
+    #[test]
+    fn to_qasm_emits_the_if_extension_syntax() {
+        let text = to_qasm(&conditioned_circuit(), "cond");
+        assert!(text.contains("if (c[0]==1) rz(0.5) q[1];"));
+    }
+
+    #[test]
+    fn if_round_trips_through_qasm_parse() {
+        let nc = conditioned_circuit();
+        let circuit = crate::qasm::parse(&to_qasm(&nc, "cond")).unwrap();
+        assert_eq!(
+            circuit.gates,
+            vec![
+                crate::ir::Gate::Measure(0, 0),
+                crate::ir::Gate::If(0, true, Box::new(crate::ir::Gate::Rz(1, 0.5))),
+            ]
+        );
+    }
+
+    #[test]
+    fn if_round_trips_through_qasm3_parse_identically_to_qasm2() {
+        let nc = conditioned_circuit();
+        let c2 = crate::qasm::parse(&to_qasm(&nc, "cond")).unwrap();
+        let c3 = crate::qasm::parse(&to_qasm3(&nc, "cond")).unwrap();
+        assert_eq!(c2.gates, c3.gates);
     }
 }

--- a/src/ibm_export.rs
+++ b/src/ibm_export.rs
@@ -54,6 +54,19 @@
 //! crate for now -- see the accompanying `submit_ibm.py` for that,
 //! since there is no official Rust SDK for IBM Quantum Platform /
 //! Qiskit Runtime.
+//!
+//! It also doesn't yet export `BackendGate::If` (a classically-
+//! conditioned gate, see `ir::Gate::If`'s doc comment) -- `lower_ibm_native`
+//! errors on one rather than guessing. Real OPENQASM 2.0's `if`
+//! conditions on a whole `creg`'s *integer value*, not one indexed bit
+//! the way this crate's own `emit.rs`/`qasm.rs` dialect extension does
+//! (see `qasm.rs`'s `parse_if_condition` doc comment) -- correctly
+//! expressing a single-bit condition in IBM's real basis needs either a
+//! dedicated size-1 `creg` per condition or a documented bit-masking
+//! convention, and this module doesn't have either yet. Emitting
+//! something that merely *parses* as QASM without actually matching
+//! what the condition means would be exactly the kind of silent-wrong
+//! output this crate's own conventions elsewhere refuse to produce.
 
 use crate::backend::{Backend, BackendCircuit, BackendGate};
 
@@ -138,6 +151,18 @@ pub fn lower_ibm_native(circuit: &BackendCircuit) -> Result<Vec<IbmInstr>, Strin
                      (Cz belongs to Rigetti, Rzz to TrappedIon -- backend::lower should \
                      never emit either for Backend::IbmQ)",
                     gate
+                ));
+            }
+            BackendGate::If(clbit, ..) => {
+                return Err(format!(
+                    "lower_ibm_native: classically-conditioned gates (clbit {}) aren't \
+                     supported yet -- real OPENQASM 2.0's `if` conditions on a whole creg's \
+                     integer value, not one indexed bit the way this crate's own qasm.rs \
+                     dialect extension does (see that module's `parse_if_condition` doc \
+                     comment); correctly expressing a single-bit condition in IBM's real \
+                     basis needs a convention this module doesn't have yet -- see this \
+                     module's own doc comment.",
+                    clbit
                 ));
             }
         }

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -93,11 +93,43 @@ pub enum Gate {
     /// `ir_optimize::disjoint` special-cases `Measure` to never commute
     /// past anything.
     Measure(usize, usize),
+    /// Applies `inner` iff classical bit `clbit` currently holds
+    /// `value` -- real, per-shot classical feed-forward control, not a
+    /// stand-in for it. This is the piece `examples/quantum_teleportation.rs`
+    /// used to work around by applying Bob's correction directly
+    /// against the `QuantumRegister` after `emit::run`, specifically
+    /// because this variant didn't exist yet -- see that example's own
+    /// doc comment (now updated) for the before/after.
+    ///
+    /// `inner` is always a single, concrete gate application, and
+    /// `Circuit::validate` enforces two shape restrictions on it:
+    /// - **Never `Measure`.** A measurement's whole job is to *produce*
+    ///   a classical bit; conditioning one on a classical bit has no
+    ///   physical meaning.
+    /// - **Never another `If`.** This stays a flat, one-level wrapper
+    ///   rather than an arbitrarily-recursive one -- every real use
+    ///   this crate has (teleportation's Bob-side correction, and any
+    ///   single conditioned gate a QASM `if` statement can express) is
+    ///   one condition on one gate.
+    ///
+    /// `native::decompose_gate` distributes the condition across every
+    /// native gate `inner` decomposes to (e.g. a conditioned `H` becomes
+    /// a conditioned `Rz`/`Ry`/`Rz` triple, each wrapped in its own
+    /// `NativeGate::If` with the same `clbit`/`value`), so a caller
+    /// never needs to build a nested `If` even for a multi-gate `inner`.
+    If(usize, bool, Box<Gate>),
 }
 
 impl Gate {
     /// Qubit indices this gate touches, in the order they appear in the
     /// gate's own argument list (control(s) before target, as written).
+    /// For `If`, this is simply `inner`'s own qubits -- an `If` occupies
+    /// exactly the wires its conditioned gate does, nothing more, so
+    /// routing (`route.rs`) and source-level reordering (`ir_optimize.rs`)
+    /// both already do the right thing by calling this generically,
+    /// with no `Gate::If`-specific case of their own needed for qubit
+    /// placement (only for whether they're allowed to *reorder* it --
+    /// see `ir_optimize::disjoint`).
     pub fn qubits(&self) -> Vec<usize> {
         use Gate::*;
         match *self {
@@ -105,6 +137,7 @@ impl Gate {
             | Rz(q, _) | Measure(q, _) => vec![q],
             Cx(a, b) | Cz(a, b) | Swap(a, b) | Rxx(a, b, _) | Ryy(a, b, _) | Rzz(a, b, _)
             | Cp(a, b, _) => vec![a, b],
+            If(_, _, ref inner) => inner.qubits(),
         }
     }
 }
@@ -159,6 +192,7 @@ impl Circuit {
                 Rzz(..) => "rzz",
                 Cp(..) => "cp",
                 Measure(..) => "measure",
+                If(..) => "if",
             };
             *counts.entry(name).or_insert(0) += 1;
         }
@@ -199,44 +233,87 @@ impl Circuit {
     /// arity mismatch a compile error, not a runtime one -- there is
     /// no way to construct an ill-formed `Gate` in the first
     /// place, so a runtime check would only ever be dead code.
+    /// 5. **`If`'s own shape.** Its classical bit index is `< self.num_clbits`,
+    ///    and its `inner` gate is neither `Measure` (see `Gate::If`'s
+    ///    doc comment on why that has no meaning) nor another `If`
+    ///    (this stays a flat, one-level wrapper). `inner` itself is
+    ///    then checked against every rule above, recursively -- so a
+    ///    conditioned `Cx(0, 0)` or a conditioned `NaN` angle is caught
+    ///    exactly as it would be unconditioned.
     pub fn validate(&self) -> Result<(), String> {
         for (i, gate) in self.gates.iter().enumerate() {
-            for q in gate.qubits() {
-                if q >= self.num_qubits {
-                    return Err(format!(
-                        "gate {} ({:?}): qubit index {} out of range for {} qubit(s)",
-                        i, gate, q, self.num_qubits
-                    ));
-                }
-            }
-            if let Gate::Measure(_, c) = *gate {
-                if c >= self.num_clbits {
-                    return Err(format!(
-                        "gate {} ({:?}): classical bit index {} out of range for {} clbit(s)",
-                        i, gate, c, self.num_clbits
-                    ));
-                }
-            }
-            let qs = gate.qubits();
-            if qs.len() == 2 && qs[0] == qs[1] {
+            self.validate_gate(i, gate)?;
+        }
+        Ok(())
+    }
+
+    /// The per-gate half of [`validate`], factored out so it can be
+    /// called recursively on the `inner` gate an `If` wraps -- see
+    /// `validate`'s point 5. `i` is always the *top-level* gate index
+    /// (an `If`'s `inner` isn't a separate entry in `self.gates`), so
+    /// every error message -- including one about a bad `inner` -- names
+    /// the `If` statement a caller actually sees in their source.
+    fn validate_gate(&self, i: usize, gate: &Gate) -> Result<(), String> {
+        for q in gate.qubits() {
+            if q >= self.num_qubits {
                 return Err(format!(
-                    "gate {} ({:?}): a two-qubit gate's arguments must be distinct, both are {}",
-                    i, gate, qs[0]
+                    "gate {} ({:?}): qubit index {} out of range for {} qubit(s)",
+                    i, gate, q, self.num_qubits
                 ));
             }
-            let angle = match *gate {
-                Gate::Rx(_, a) | Gate::Ry(_, a) | Gate::Rz(_, a) => Some(a),
-                Gate::Rxx(_, _, a) | Gate::Ryy(_, _, a) | Gate::Rzz(_, _, a) => Some(a),
-                Gate::Cp(_, _, a) => Some(a),
-                _ => None,
-            };
-            if let Some(a) = angle {
-                if !a.is_finite() {
+        }
+        if let Gate::Measure(_, c) = *gate {
+            if c >= self.num_clbits {
+                return Err(format!(
+                    "gate {} ({:?}): classical bit index {} out of range for {} clbit(s)",
+                    i, gate, c, self.num_clbits
+                ));
+            }
+        }
+        let qs = gate.qubits();
+        if qs.len() == 2 && qs[0] == qs[1] {
+            return Err(format!(
+                "gate {} ({:?}): a two-qubit gate's arguments must be distinct, both are {}",
+                i, gate, qs[0]
+            ));
+        }
+        let angle = match *gate {
+            Gate::Rx(_, a) | Gate::Ry(_, a) | Gate::Rz(_, a) => Some(a),
+            Gate::Rxx(_, _, a) | Gate::Ryy(_, _, a) | Gate::Rzz(_, _, a) => Some(a),
+            Gate::Cp(_, _, a) => Some(a),
+            _ => None,
+        };
+        if let Some(a) = angle {
+            if !a.is_finite() {
+                return Err(format!(
+                    "gate {} ({:?}): parameter {} is not finite (NaN or infinite)",
+                    i, gate, a
+                ));
+            }
+        }
+        if let Gate::If(clbit, _, ref inner) = *gate {
+            if clbit >= self.num_clbits {
+                return Err(format!(
+                    "gate {} ({:?}): If's classical bit index {} out of range for {} clbit(s)",
+                    i, gate, clbit, self.num_clbits
+                ));
+            }
+            match inner.as_ref() {
+                Gate::Measure(..) => {
                     return Err(format!(
-                        "gate {} ({:?}): parameter {} is not finite (NaN or infinite)",
-                        i, gate, a
+                        "gate {} ({:?}): If cannot condition a Measure -- a measurement \
+                         produces a classical bit, it doesn't consume one",
+                        i, gate
                     ));
                 }
+                Gate::If(..) => {
+                    return Err(format!(
+                        "gate {} ({:?}): If cannot condition another If -- nested classical \
+                         conditions aren't supported here, flatten to a single condition",
+                        i, gate
+                    ));
+                }
+                _ => self.validate_gate(i, inner)?,
             }
         }
         Ok(())
@@ -353,5 +430,82 @@ mod tests {
         assert_eq!(Gate::Measure(2, 0).qubits(), vec![2]);
         assert_eq!(Gate::Cx(0, 1).qubits(), vec![0, 1]);
         assert_eq!(Gate::Rzz(4, 5, 0.1).qubits(), vec![4, 5]);
+    }
+
+    #[test]
+    fn if_qubits_delegates_to_inner() {
+        // A single-qubit inner...
+        assert_eq!(Gate::If(0, true, Box::new(Gate::X(2))).qubits(), vec![2]);
+        // ...and a two-qubit inner, unchanged from what `route.rs`/
+        // `ir_optimize.rs` need to place/reorder it correctly with no
+        // `Gate::If`-specific case of their own (see `qubits`'s doc
+        // comment).
+        assert_eq!(Gate::If(0, true, Box::new(Gate::Cx(1, 3))).qubits(), vec![1, 3]);
+    }
+
+    #[test]
+    fn accepts_well_formed_if() {
+        let mut c = Circuit::new(2);
+        c.num_clbits = 1;
+        c.push(Gate::Measure(0, 0)).push(Gate::If(0, true, Box::new(Gate::X(1))));
+        assert!(c.validate().is_ok());
+    }
+
+    #[test]
+    fn rejects_if_clbit_out_of_range() {
+        let mut c = Circuit::new(2);
+        c.num_clbits = 1;
+        c.push(Gate::If(5, true, Box::new(Gate::X(1))));
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_if_conditioning_a_measure() {
+        let mut c = Circuit::new(2);
+        c.num_clbits = 1;
+        c.push(Gate::If(0, true, Box::new(Gate::Measure(1, 0))));
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_nested_if() {
+        let mut c = Circuit::new(2);
+        c.num_clbits = 1;
+        c.push(Gate::If(0, true, Box::new(Gate::If(0, false, Box::new(Gate::X(1))))));
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_if_wrapping_a_qubit_out_of_range() {
+        // The inner gate's own qubit-range check must still fire
+        // through the wrapper.
+        let mut c = Circuit::new(2);
+        c.num_clbits = 1;
+        c.push(Gate::If(0, true, Box::new(Gate::X(9))));
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_if_wrapping_a_nan_angle() {
+        let mut c = Circuit::new(1);
+        c.num_clbits = 1;
+        c.push(Gate::If(0, true, Box::new(Gate::Rz(0, f64::NAN))));
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_if_wrapping_a_self_targeting_two_qubit_gate() {
+        let mut c = Circuit::new(2);
+        c.num_clbits = 1;
+        c.push(Gate::If(0, true, Box::new(Gate::Cx(0, 0))));
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn if_counts_under_its_own_mnemonic() {
+        let mut c = Circuit::new(1);
+        c.num_clbits = 1;
+        c.push(Gate::If(0, true, Box::new(Gate::X(0))));
+        assert_eq!(c.gate_counts().get("if"), Some(&1));
     }
 }

--- a/src/ir_optimize.rs
+++ b/src/ir_optimize.rs
@@ -94,7 +94,16 @@ fn disjoint(a: &Gate, b: &Gate) -> bool {
     // in either direction. Conservative on purpose: this crate does
     // not yet track classical-bit dependencies precisely enough to
     // reorder Measures safely (see `ir::Gate::Measure`'s doc comment).
-    if matches!(a, Gate::Measure(..)) || matches!(b, Gate::Measure(..)) {
+    //
+    // `If(clbit, ..)` gets the same treatment, for the same reason: it
+    // *reads* a classical bit some earlier `Measure` wrote, and reads
+    // conflict with writes exactly the way two writes to the same bit
+    // do -- reordering it past the `Measure` that produced the value
+    // it's conditioned on (or past another `If` reading the same bit)
+    // could change what it observes, even though its own *qubit* set
+    // may be disjoint from either. Same conservative call as `Measure`:
+    // never a commute candidate, in either direction.
+    if matches!(a, Gate::Measure(..) | Gate::If(..)) || matches!(b, Gate::Measure(..) | Gate::If(..)) {
         return false;
     }
     let qa: HashSet<usize> = qubits_of(a).into_iter().collect();
@@ -385,6 +394,12 @@ mod tests {
                  No test in this file exercises Measure; this arm exists only to satisfy \
                  exhaustiveness."
             ),
+            Gate::If(..) => panic!(
+                "apply_gate: If has no fidelity-based test yet, for the same reason as \
+                 Measure above -- it reads a classical bit this direct-simulation comparison \
+                 has nowhere to produce. No test in this file exercises If; this arm exists \
+                 only to satisfy exhaustiveness."
+            ),
         }
     }
 
@@ -483,6 +498,35 @@ mod tests {
         c.push(Gate::Measure(0, 0)).push(Gate::Measure(1, 0));
         let opt = optimize_ir(&c);
         assert_eq!(opt.gates, vec![Gate::Measure(0, 0), Gate::Measure(1, 0)]);
+    }
+
+    #[test]
+    fn never_reorders_if_past_a_qubit_disjoint_gate() {
+        // Same story as never_reorders_measure_past_a_qubit_disjoint_gate,
+        // one level up: If(0, true, X(1)) reads clbit 0, and X(2) is on
+        // a different qubit -- qubit-disjoint alone would make this
+        // look swappable, but an If must never be slid past anything.
+        let mut c = Circuit::new(3);
+        c.num_clbits = 1;
+        let if_gate = Gate::If(0, true, Box::new(Gate::X(1)));
+        c.push(if_gate.clone()).push(Gate::X(2));
+        let opt = optimize_ir(&c);
+        assert_eq!(opt.gates, vec![if_gate, Gate::X(2)]);
+    }
+
+    #[test]
+    fn never_reorders_if_past_the_measure_it_depends_on() {
+        // The exact teleportation shape: a Measure whose outcome an If
+        // later reads. Even though If(0, ..) touches a different qubit
+        // than Measure(0, 0), reordering them would let the correction
+        // run before the outcome it's conditioned on has been produced.
+        let mut c = Circuit::new(2);
+        c.num_clbits = 1;
+        let measure = Gate::Measure(0, 0);
+        let if_gate = Gate::If(0, true, Box::new(Gate::X(1)));
+        c.push(measure.clone()).push(if_gate.clone());
+        let opt = optimize_ir(&c);
+        assert_eq!(opt.gates, vec![measure, if_gate]);
     }
 
     #[test]

--- a/src/native.rs
+++ b/src/native.rs
@@ -15,7 +15,15 @@
 use crate::ir::{Circuit, Gate};
 use std::f64::consts::{FRAC_PI_2, PI};
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+// NOTE: no longer `Copy` -- `If`'s `Box<NativeGate>` field can't be
+// (a `Box` is a heap allocation; `Copy` would mean silently duplicating
+// the allocation on every implicit copy, which the trait's contract
+// forbids). Every call site that used to lean on `Copy` (mostly
+// `optimize.rs`'s peephole passes) now clones explicitly instead --
+// see that module's `merge_pass`/`drop_zero_pass` for the specific
+// fix. Still `Clone`, so nothing that only needed an owned duplicate
+// (as opposed to an *implicit* one) had to change shape.
+#[derive(Debug, Clone, PartialEq)]
 pub enum NativeGate {
     Rz(usize, f64),
     Ry(usize, f64),
@@ -24,6 +32,21 @@ pub enum NativeGate {
     /// unitary rewrite target, so it never appears on the left-hand
     /// side of any decomposition identity in this module.
     Measure(usize, usize),
+    /// The native-level counterpart of `ir::Gate::If`: applies `inner`
+    /// iff classical bit `clbit` holds `value`. Produced by
+    /// `decompose_gate` distributing a source-level `If`'s condition
+    /// across every native gate its `inner` decomposes to -- so a
+    /// conditioned `H`, for instance, becomes a conditioned
+    /// `Rz`/`Ry`/`Rz` triple (three separate `NativeGate::If`s, same
+    /// `clbit`/`value` on each), not one `If` wrapping all three. That
+    /// shape is what `emit.rs` actually needs to execute correctly: a
+    /// physical pulse either fires or it doesn't, one at a time, and
+    /// each one independently depends on the same classical bit.
+    /// `inner` is always a bare `Rz`/`Ry`/`Rzz` -- never `Measure` or
+    /// another `If`, same restriction as `ir::Gate::If` (enforced there
+    /// by `Circuit::validate`, before decomposition ever runs, so it
+    /// isn't re-checked here).
+    If(usize, bool, Box<NativeGate>),
 }
 
 #[derive(Debug, Clone, Default)]
@@ -57,18 +80,28 @@ impl NativeCircuit {
     /// unitary gate, so a per-gate depolarizing-error model has nothing
     /// to say about it, and counting it as a "single-qubit gate" here
     /// would silently make `fidelity::estimate_circuit_fidelity` price
-    /// a measurement as if it were a rotation.
+    /// a measurement as if it were a rotation. `If` is unwrapped and its
+    /// `inner` counted as whatever it is -- a conditioned rotation still
+    /// costs the same physical pulse budget as an unconditioned one on
+    /// real hardware; the classical condition decides whether the pulse
+    /// fires at runtime, not whether it needs to be priced into the
+    /// budget if it does.
     pub fn gate_counts(&self) -> (usize, usize) {
         let mut single = 0;
         let mut two = 0;
         for g in &self.gates {
-            match g {
-                NativeGate::Rz(..) | NativeGate::Ry(..) => single += 1,
-                NativeGate::Rzz(..) => two += 1,
-                NativeGate::Measure(..) => {}
-            }
+            count_gate(g, &mut single, &mut two);
         }
         (single, two)
+    }
+}
+
+fn count_gate(g: &NativeGate, single: &mut usize, two: &mut usize) {
+    match g {
+        NativeGate::Rz(..) | NativeGate::Ry(..) => *single += 1,
+        NativeGate::Rzz(..) => *two += 1,
+        NativeGate::Measure(..) => {}
+        NativeGate::If(_, _, inner) => count_gate(inner, single, two),
     }
 }
 
@@ -273,6 +306,23 @@ pub fn decompose(circuit: &Circuit) -> NativeCircuit {
 pub(crate) fn decompose_gate(nc: &mut NativeCircuit, gate: &Gate) {
     match *gate {
         Gate::Measure(q, c) => nc.push(NativeGate::Measure(q, c)),
+        Gate::If(clbit, value, ref inner) => {
+            // `inner` is decomposed on its own into a fresh scratch
+            // circuit first (never Measure or another If -- see
+            // `ir::Gate::If`'s doc comment and `Circuit::validate`,
+            // which rejects both before this ever runs), then every
+            // native gate that decomposition produced is wrapped in the
+            // same condition. A single source-level `If(H)` becoming
+            // three separately-conditioned native gates (Rz/Ry/Rz, one
+            // `NativeGate::If` each) rather than one `If` wrapping all
+            // three is deliberate -- see `NativeGate::If`'s own doc
+            // comment for why that's the shape `emit.rs` needs.
+            let mut tmp = NativeCircuit::new(nc.num_qubits);
+            decompose_gate(&mut tmp, inner);
+            for g in tmp.gates {
+                nc.push(NativeGate::If(clbit, value, Box::new(g)));
+            }
+        }
         Gate::H(q) => push_single(nc, q, m_h()),
         Gate::X(q) => push_single(nc, q, m_x()),
         Gate::Y(q) => push_single(nc, q, m_y()),
@@ -384,4 +434,60 @@ pub(crate) fn approx_eq_up_to_global_phase(a: Mat2, b: Mat2) -> bool {
         }
     }
     true
+}
+#[cfg(test)]
+mod if_decompose_tests {
+    use super::*;
+    use crate::ir::{Circuit, Gate};
+
+    #[test]
+    fn decomposes_a_conditioned_single_native_gate_into_one_wrapped_if() {
+        let mut c = Circuit::new(1);
+        c.num_clbits = 1;
+        c.push(Gate::If(0, true, Box::new(Gate::Rz(0, 0.5))));
+        let nc = decompose(&c);
+        assert_eq!(
+            nc.gates,
+            vec![NativeGate::If(0, true, Box::new(NativeGate::Rz(0, 0.5)))]
+        );
+    }
+
+    #[test]
+    fn decomposes_a_conditioned_multi_gate_source_gate_into_one_wrapped_if_per_native_gate() {
+        // H decomposes to an Rz/Ry/Rz triple (see push_single) -- every
+        // one of those three must carry the *same* condition, not just
+        // the first (see NativeGate::If's doc comment).
+        let mut c = Circuit::new(1);
+        c.num_clbits = 1;
+        c.push(Gate::If(2, false, Box::new(Gate::H(0))));
+        let nc = decompose(&c);
+        assert!(!nc.gates.is_empty());
+        for g in &nc.gates {
+            match g {
+                NativeGate::If(clbit, value, inner) => {
+                    assert_eq!(*clbit, 2);
+                    assert_eq!(*value, false);
+                    assert!(matches!(inner.as_ref(), NativeGate::Rz(..) | NativeGate::Ry(..)));
+                }
+                other => panic!("expected every native gate to be If-wrapped, got {:?}", other),
+            }
+        }
+    }
+
+    #[test]
+    fn gate_counts_prices_a_conditioned_rotation_the_same_as_an_unconditioned_one() {
+        let mut conditioned = NativeCircuit::new(1);
+        conditioned.push(NativeGate::If(0, true, Box::new(NativeGate::Rz(0, 0.1))));
+        let mut plain = NativeCircuit::new(1);
+        plain.push(NativeGate::Rz(0, 0.1));
+        assert_eq!(conditioned.gate_counts(), plain.gate_counts());
+        assert_eq!(conditioned.gate_counts(), (1, 0));
+    }
+
+    #[test]
+    fn gate_counts_prices_a_conditioned_two_qubit_gate_as_two_qubit() {
+        let mut nc = NativeCircuit::new(2);
+        nc.push(NativeGate::If(0, true, Box::new(NativeGate::Rzz(0, 1, 0.2))));
+        assert_eq!(nc.gate_counts(), (0, 1));
+    }
 }

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -52,14 +52,18 @@ fn wrap_angle(theta: f64) -> f64 {
 
 fn merge_pass(gates: &[NativeGate]) -> Vec<NativeGate> {
     let mut out: Vec<NativeGate> = Vec::with_capacity(gates.len());
-    for &g in gates {
-        let merged = out.last().copied().and_then(|last| try_merge(last, g));
+    for g in gates {
+        // `NativeGate` is no longer `Copy` (see its own doc comment --
+        // `If`'s `Box` field can't be), so this clones explicitly
+        // rather than leaning on an implicit copy the way this loop
+        // used to (`for &g in gates`).
+        let merged = out.last().cloned().and_then(|last| try_merge(last, g.clone()));
         match merged {
             Some(combined) => {
                 out.pop();
                 out.push(combined);
             }
-            None => out.push(g),
+            None => out.push(g.clone()),
         }
     }
     out
@@ -88,7 +92,7 @@ fn try_merge(last: NativeGate, g: NativeGate) -> Option<NativeGate> {
 fn drop_zero_pass(gates: &[NativeGate]) -> Vec<NativeGate> {
     gates
         .iter()
-        .copied()
+        .cloned()
         .filter(|g| match g {
             NativeGate::Rz(_, a) | NativeGate::Ry(_, a) => a.abs() > EPS,
             NativeGate::Rzz(_, _, a) => a.abs() > EPS,
@@ -96,6 +100,21 @@ fn drop_zero_pass(gates: &[NativeGate]) -> Vec<NativeGate> {
             // an "angle" to net to zero, and it's a real classical side
             // effect the caller depends on.
             NativeGate::Measure(..) => true,
+            // Drop iff the *wrapped* gate would be dropped on its own --
+            // an If(clbit, value, Rz(q, ~0)) is a no-op regardless of
+            // clbit's value, exactly as much as a bare Rz(q, ~0) would
+            // be, so this recurses into the same rule rather than
+            // keeping every If unconditionally (which would leave
+            // genuinely-zero conditioned rotations behind forever).
+            // Measure/If can't actually appear as `inner` here (see
+            // NativeGate::If's doc comment), but are matched
+            // conservatively (never dropped) rather than left
+            // unreachable, so this stays a total function.
+            NativeGate::If(_, _, inner) => match inner.as_ref() {
+                NativeGate::Rz(_, a) | NativeGate::Ry(_, a) => a.abs() > EPS,
+                NativeGate::Rzz(_, _, a) => a.abs() > EPS,
+                NativeGate::Measure(..) | NativeGate::If(..) => true,
+            },
         })
         .collect()
 }
@@ -139,6 +158,39 @@ mod tests {
         nc.push(NativeGate::Measure(0, 0));
         let opt = optimize(&nc);
         assert_eq!(opt.gates, vec![NativeGate::Measure(0, 0)]);
+    }
+
+    #[test]
+    fn keeps_a_conditioned_nonzero_rotation() {
+        let mut nc = NativeCircuit::new(1);
+        nc.push(NativeGate::If(0, true, Box::new(NativeGate::Rz(0, 0.5))));
+        let opt = optimize(&nc);
+        assert_eq!(opt.gates, vec![NativeGate::If(0, true, Box::new(NativeGate::Rz(0, 0.5)))]);
+    }
+
+    #[test]
+    fn drops_a_conditioned_zero_rotation() {
+        // If(clbit, value, Rz(q, ~0)) is a no-op no matter what clbit
+        // holds -- same as an unconditioned zero-angle Rz.
+        let mut nc = NativeCircuit::new(1);
+        nc.push(NativeGate::If(0, true, Box::new(NativeGate::Rz(0, 0.0))));
+        let opt = optimize(&nc);
+        assert!(opt.gates.is_empty());
+    }
+
+    #[test]
+    fn never_merges_two_adjacent_conditioned_rotations() {
+        // try_merge only matches bare Rz/Ry/Rzz pairs -- two If-wrapped
+        // rotations, even same-axis and same-qubit, fall through to its
+        // wildcard and stay separate. (Fusing them would only be valid
+        // if both share the same clbit/value, which this pass doesn't
+        // currently check -- see this module's doc comment for the
+        // scope this pass covers.)
+        let mut nc = NativeCircuit::new(1);
+        nc.push(NativeGate::If(0, true, Box::new(NativeGate::Rz(0, 0.2))));
+        nc.push(NativeGate::If(0, true, Box::new(NativeGate::Rz(0, 0.3))));
+        let opt = optimize(&nc);
+        assert_eq!(opt.gates.len(), 2, "conditioned rotations should not be fused by this pass");
     }
 
     #[test]

--- a/src/pulse.rs
+++ b/src/pulse.rs
@@ -406,98 +406,127 @@ pub fn schedule(bc: &BackendCircuit, cal: &PulseCalibration) -> Result<Schedule,
     let mut busy_until: HashMap<usize, f64> = HashMap::new();
     let mut instructions = Vec::with_capacity(bc.gates.len());
 
+    for g in &bc.gates {
+        schedule_one(g, cal, &mut busy_until, &mut instructions)?;
+    }
+
+    Ok(Schedule { backend: bc.backend, instructions })
+}
+
+/// One gate's contribution to a [`Schedule`] -- the per-gate body
+/// [`schedule`]'s loop used to inline directly, factored out so
+/// `BackendGate::If` can recurse into its `inner` with the same logic
+/// rather than a second copy of it.
+fn schedule_one(
+    g: &BackendGate,
+    cal: &PulseCalibration,
+    busy_until: &mut HashMap<usize, f64>,
+    instructions: &mut Vec<PulseInstruction>,
+) -> Result<(), String> {
     fn qubit_time(q: usize, busy_until: &HashMap<usize, f64>) -> f64 {
         *busy_until.get(&q).unwrap_or(&0.0)
     }
 
-    for g in &bc.gates {
-        match *g {
-            BackendGate::Rz(q, theta) => {
-                let t = qubit_time(q, &busy_until);
-                instructions.push(PulseInstruction::ShiftPhase {
-                    channel: Channel::Drive(q),
-                    start_time_ns: t,
-                    angle_rad: theta,
-                });
-                // Zero duration: `busy_until[q]` is deliberately left
-                // untouched -- see this module's doc comment on
-                // virtual-Z.
-            }
-            BackendGate::Rot(q, theta) => {
-                let t = qubit_time(q, &busy_until);
-                let amplitude = cal.rot.pi_amplitude * theta / PI;
-                instructions.push(PulseInstruction::Play {
-                    channel: Channel::Drive(q),
-                    start_time_ns: t,
-                    duration_ns: cal.rot.duration_ns,
-                    envelope: Envelope::Drag {
-                        sigma_ns: cal.rot.sigma_ns,
-                        beta: cal.rot.drag_beta,
-                    },
-                    amplitude,
-                });
-                busy_until.insert(q, t + cal.rot.duration_ns);
-            }
-            BackendGate::Cx(a, b) | BackendGate::Cz(a, b) => {
-                let t = qubit_time(a, &busy_until).max(qubit_time(b, &busy_until));
-                instructions.push(PulseInstruction::Play {
-                    channel: Channel::Control(a, b),
-                    start_time_ns: t,
-                    duration_ns: cal.two_qubit.duration_ns,
-                    envelope: Envelope::GaussianSquare {
-                        sigma_ns: cal.two_qubit.sigma_ns,
-                        risefall_ns: cal.two_qubit.risefall_ns,
-                    },
-                    amplitude: cal.two_qubit.amplitude,
-                });
-                let end = t + cal.two_qubit.duration_ns;
-                busy_until.insert(a, end);
-                busy_until.insert(b, end);
-            }
-            BackendGate::Rzz(a, b, theta) => {
-                let rzz_cal = cal.rzz.ok_or_else(|| {
-                    format!(
-                        "pulse scheduling for Rzz (TrappedIon's native two-qubit gate, on \
-                         qubits {a},{b}) has no calibration entry on backend {:?} -- see \
-                         this module's doc comment on backend coverage",
-                        cal.backend
-                    )
-                })?;
-                let t = qubit_time(a, &busy_until).max(qubit_time(b, &busy_until));
-                let amplitude = rzz_cal.pi_amplitude * theta / PI;
-                instructions.push(PulseInstruction::Play {
-                    channel: Channel::Control(a, b),
-                    start_time_ns: t,
-                    duration_ns: rzz_cal.duration_ns,
-                    envelope: Envelope::GaussianSquare {
-                        sigma_ns: rzz_cal.sigma_ns,
-                        risefall_ns: rzz_cal.risefall_ns,
-                    },
-                    amplitude,
-                });
-                let end = t + rzz_cal.duration_ns;
-                busy_until.insert(a, end);
-                busy_until.insert(b, end);
-            }
-            BackendGate::Measure(q, _c) => {
-                let t = qubit_time(q, &busy_until);
-                let duration = cal.readout_duration_ns;
-                instructions.push(PulseInstruction::Play {
-                    channel: Channel::Readout(q),
-                    start_time_ns: t,
-                    duration_ns: duration,
-                    envelope: Envelope::GaussianSquare {
-                        sigma_ns: duration / 8.0,
-                        risefall_ns: duration / 8.0,
-                    },
-                    amplitude: 1.0,
-                });
-                busy_until.insert(q, t + duration);
-            }
+    match *g {
+        BackendGate::Rz(q, theta) => {
+            let t = qubit_time(q, busy_until);
+            instructions.push(PulseInstruction::ShiftPhase {
+                channel: Channel::Drive(q),
+                start_time_ns: t,
+                angle_rad: theta,
+            });
+            // Zero duration: `busy_until[q]` is deliberately left
+            // untouched -- see this module's doc comment on
+            // virtual-Z.
+        }
+        BackendGate::Rot(q, theta) => {
+            let t = qubit_time(q, busy_until);
+            let amplitude = cal.rot.pi_amplitude * theta / PI;
+            instructions.push(PulseInstruction::Play {
+                channel: Channel::Drive(q),
+                start_time_ns: t,
+                duration_ns: cal.rot.duration_ns,
+                envelope: Envelope::Drag { sigma_ns: cal.rot.sigma_ns, beta: cal.rot.drag_beta },
+                amplitude,
+            });
+            busy_until.insert(q, t + cal.rot.duration_ns);
+        }
+        BackendGate::Cx(a, b) | BackendGate::Cz(a, b) => {
+            let t = qubit_time(a, busy_until).max(qubit_time(b, busy_until));
+            instructions.push(PulseInstruction::Play {
+                channel: Channel::Control(a, b),
+                start_time_ns: t,
+                duration_ns: cal.two_qubit.duration_ns,
+                envelope: Envelope::GaussianSquare {
+                    sigma_ns: cal.two_qubit.sigma_ns,
+                    risefall_ns: cal.two_qubit.risefall_ns,
+                },
+                amplitude: cal.two_qubit.amplitude,
+            });
+            let end = t + cal.two_qubit.duration_ns;
+            busy_until.insert(a, end);
+            busy_until.insert(b, end);
+        }
+        BackendGate::Rzz(a, b, theta) => {
+            let rzz_cal = cal.rzz.ok_or_else(|| {
+                format!(
+                    "pulse scheduling for Rzz (TrappedIon's native two-qubit gate, on \
+                     qubits {a},{b}) has no calibration entry on backend {:?} -- see \
+                     this module's doc comment on backend coverage",
+                    cal.backend
+                )
+            })?;
+            let t = qubit_time(a, busy_until).max(qubit_time(b, busy_until));
+            let amplitude = rzz_cal.pi_amplitude * theta / PI;
+            instructions.push(PulseInstruction::Play {
+                channel: Channel::Control(a, b),
+                start_time_ns: t,
+                duration_ns: rzz_cal.duration_ns,
+                envelope: Envelope::GaussianSquare {
+                    sigma_ns: rzz_cal.sigma_ns,
+                    risefall_ns: rzz_cal.risefall_ns,
+                },
+                amplitude,
+            });
+            let end = t + rzz_cal.duration_ns;
+            busy_until.insert(a, end);
+            busy_until.insert(b, end);
+        }
+        BackendGate::Measure(q, _c) => {
+            let t = qubit_time(q, busy_until);
+            let duration = cal.readout_duration_ns;
+            instructions.push(PulseInstruction::Play {
+                channel: Channel::Readout(q),
+                start_time_ns: t,
+                duration_ns: duration,
+                envelope: Envelope::GaussianSquare {
+                    sigma_ns: duration / 8.0,
+                    risefall_ns: duration / 8.0,
+                },
+                amplitude: 1.0,
+            });
+            busy_until.insert(q, t + duration);
+        }
+        BackendGate::If(_, _, ref inner) => {
+            // Scheduled exactly as `inner` would be on its own --
+            // *this* static `Schedule` only ever describes which
+            // pulses exist and when, never whether one actually fires
+            // at runtime (see `emit.rs`'s execution of this variant,
+            // which is what makes that call). That split mirrors how
+            // this crate already treats the analogous case one layer
+            // up: `backend::lower`'s `If` handling compiles the pulse
+            // unconditionally into the schedule; the real-time
+            // classical feed-forward decision belongs to control
+            // electronics this static model doesn't represent, not to
+            // schedule construction. A genuine dynamic-circuits
+            // scheduler -- one that can express "wait for the
+            // classical result, then branch, with real feed-forward
+            // latency" -- is real, separate follow-on work this
+            // function doesn't attempt.
+            schedule_one(inner, cal, busy_until, instructions)?;
         }
     }
-
-    Ok(Schedule { backend: bc.backend, instructions })
+    Ok(())
 }
 
 #[cfg(test)]
@@ -812,5 +841,44 @@ mod tests {
         // And each backend's own calibration still works.
         assert!(schedule(&ibm_bc, &cal()).is_ok());
         assert!(schedule(&rigetti_bc, &rigetti_ankaa3_pulse_calibration()).is_ok());
+    }
+
+    #[test]
+    fn if_is_scheduled_exactly_as_its_inner_gate_would_be() {
+        // BackendGate::If(_, _, Rot(..)) should produce the identical
+        // Play instruction (minus the classical condition, which this
+        // static Schedule model doesn't represent at all -- see
+        // schedule_one's own doc comment on that variant) that a bare
+        // Rot would, at the same time, with the same effect on
+        // busy_until. Built via backend::lower on an empty Circuit
+        // (like this file's other tests) since BackendCircuit::new is
+        // private outside backend.rs -- push is pub(crate), so the
+        // gates themselves can still be added directly.
+        let mut conditioned = backend::lower(&Circuit::new(1), Backend::TrappedIon);
+        conditioned.push(BackendGate::If(0, true, Box::new(BackendGate::Rot(0, PI))));
+        let mut plain = backend::lower(&Circuit::new(1), Backend::TrappedIon);
+        plain.push(BackendGate::Rot(0, PI));
+
+        let sched_conditioned = schedule(&conditioned, &trapped_ion_pulse_calibration()).unwrap();
+        let sched_plain = schedule(&plain, &trapped_ion_pulse_calibration()).unwrap();
+        assert_eq!(sched_conditioned.instructions, sched_plain.instructions);
+    }
+
+    #[test]
+    fn if_wrapping_a_two_qubit_gate_still_advances_busy_until_on_both_wires() {
+        // A conditioned two-qubit gate must still block a later
+        // single-qubit pulse on either of its wires from starting
+        // early -- same overlap-freedom guarantee as an unconditioned
+        // two-qubit gate.
+        let mut bc = backend::lower(&Circuit::new(2), Backend::TrappedIon);
+        bc.push(BackendGate::If(0, true, Box::new(BackendGate::Rzz(0, 1, PI / 2.0))));
+        bc.push(BackendGate::Rot(0, PI));
+        let sched = schedule(&bc, &trapped_ion_pulse_calibration()).unwrap();
+        assert!(
+            sched.has_no_overlaps(),
+            "a conditioned two-qubit gate must still reserve both its wires: {:?}",
+            sched.instructions
+        );
+        assert_eq!(sched.instructions.len(), 2, "expected exactly the Rzz pulse plus the Rot pulse");
     }
 }

--- a/src/qasm.rs
+++ b/src/qasm.rs
@@ -6,10 +6,24 @@
 //! plus the handful of standard `qelib1.inc`/`stdgates.inc` mnemonics
 //! circuits exported from other tools (Qiskit, etc.) commonly use for
 //! the same gate set. It is intentionally not a general OPENQASM
-//! parser: no gate definitions, no classical control, no includes/
-//! registers beyond a single qubit register and a single classical
-//! register, no barriers. Anything outside that subset is a parse
-//! error naming the offending line, rather than a silent skip.
+//! parser: no gate definitions, no includes/registers beyond a single
+//! qubit register and a single classical register, no barriers.
+//! Anything outside that subset is a parse error naming the offending
+//! line, rather than a silent skip.
+//!
+//! # Classical control
+//! One narrow slice of classical control *is* supported: this crate's
+//! own `if (c[N]==0|1) <gate-stmt>;` extension (produced by
+//! `crate::emit::to_qasm`/`to_qasm3` for `NativeGate::If`, parsed here
+//! by [`parse_if_condition`]). This is not standard OPENQASM -- real
+//! QASM 2.0's `if` conditions on a whole `creg`'s integer value, not
+//! one indexed bit, and QASM 3.0 has no single-statement (non-block)
+//! `if` at all -- but it's the same kind of deliberate, documented
+//! departure from the standard already noted below for `rzz`/`ryy`,
+//! scoped to exactly what `ir::Gate::If` needs: one condition on one
+//! gate, never a measure, never a nested condition (see
+//! `Circuit::validate`, which rejects both of those regardless of how
+//! a `Circuit` was built).
 //!
 //! # QASM 2.0 vs. 3.0
 //!
@@ -105,6 +119,51 @@ pub fn parse(source: &str) -> Result<Circuit, String> {
             let (q, c) = parse_measure_statement(rest, lineno)?;
             check_measure_range(q, n, c, c_count, lineno, stmt)?;
             circuit.gates.push(Gate::Measure(q, c));
+            continue;
+        }
+        // This crate's own classical-control extension:
+        // `if (c[N]==0|1) <gate-stmt>;` -- see this module's doc
+        // comment and `parse_if_condition`'s own doc comment for what
+        // this is (and isn't) standard for.
+        if let Some(rest) = stmt.strip_prefix("if") {
+            let n = num_qubits.ok_or_else(|| {
+                format!("line {}: `if` before a qubit register declaration: `{}`", lineno, stmt)
+            })?;
+            let c_count = num_clbits.ok_or_else(|| {
+                format!("line {}: `if` before a classical register declaration: `{}`", lineno, stmt)
+            })?;
+            let (clbit, value, inner_stmt) = parse_if_condition(rest, lineno)?;
+            if clbit >= c_count {
+                return Err(format!(
+                    "line {}: classical bit index {} out of range for a {}-bit register: `{}`",
+                    lineno, clbit, c_count, stmt
+                ));
+            }
+            let inner_trimmed = inner_stmt.trim();
+            if inner_trimmed.starts_with("measure") {
+                return Err(format!(
+                    "line {}: `if` cannot condition a `measure` -- a measurement produces a \
+                     classical bit, it doesn't consume one: `{}`",
+                    lineno, stmt
+                ));
+            }
+            if inner_trimmed.starts_with("if") {
+                return Err(format!(
+                    "line {}: `if` cannot condition another `if` -- nested classical \
+                     conditions aren't supported here: `{}`",
+                    lineno, stmt
+                ));
+            }
+            let inner_gate = parse_gate_statement(inner_trimmed, lineno)?;
+            for q in inner_gate.qubits() {
+                if q >= n {
+                    return Err(format!(
+                        "line {}: qubit index {} out of range for a {}-qubit register: `{}`",
+                        lineno, q, n, stmt
+                    ));
+                }
+            }
+            circuit.gates.push(Gate::If(clbit, value, Box::new(inner_gate)));
             continue;
         }
         // QASM 3.0's assignment-style measure: `c[0] = measure q[0];`
@@ -419,6 +478,45 @@ fn parse_measure_statement(rest: &str, lineno: usize) -> Result<(usize, usize), 
     Ok((q, c))
 }
 
+/// Parses this crate's own classical-control extension --
+/// `if (c[N]==0|1) <gate-stmt>` -- after the leading `if` keyword has
+/// already been stripped. Not standard OPENQASM (see this module's doc
+/// comment) -- `emit.rs::to_qasm`/`to_qasm3`'s own dialect for a
+/// single classically-conditioned gate. Returns `(clbit, value,
+/// remaining_statement_text)`; the caller is responsible for rejecting
+/// a `measure`/`if` as the remaining statement (see `Circuit::validate`'s
+/// matching rule) and then parsing whatever's left with the ordinary
+/// [`parse_gate_statement`].
+fn parse_if_condition(rest: &str, lineno: usize) -> Result<(usize, bool, &str), String> {
+    let rest = rest.trim_start();
+    let open = rest
+        .strip_prefix('(')
+        .ok_or_else(|| format!("line {}: `if` missing `(condition)`: `if{}`", lineno, rest))?;
+    let close = open
+        .find(')')
+        .ok_or_else(|| format!("line {}: `if` missing closing `)`: `if{}`", lineno, rest))?;
+    let condition = &open[..close];
+    let eq = condition.find("==").ok_or_else(|| {
+        format!(
+            "line {}: `if` condition must be `c[N]==0` or `c[N]==1`: `if({})`",
+            lineno, condition
+        )
+    })?;
+    let clbit = parse_index_ref(&condition[..eq], lineno)?;
+    let rhs = condition[eq + 2..].trim();
+    let value = match rhs {
+        "0" => false,
+        "1" => true,
+        other => {
+            return Err(format!(
+                "line {}: `if` condition value must be `0` or `1`, got `{}`: `if({})`",
+                lineno, other, condition
+            ))
+        }
+    };
+    Ok((clbit, value, &open[close + 1..]))
+}
+
 #[cfg(test)]
 mod measure_tests {
     use super::*;
@@ -530,5 +628,77 @@ mod qasm3_tests {
             circuit.gates,
             vec![Gate::H(0), Gate::Rz(1, 0.5), Gate::Rzz(0, 2, 1.2)]
         );
+    }
+}
+
+#[cfg(test)]
+mod if_tests {
+    use super::*;
+
+    #[test]
+    fn parses_a_conditioned_gate() {
+        let src = "OPENQASM 2.0;\nqreg q[2];\ncreg c[1];\nmeasure q[0] -> c[0];\nif (c[0]==1) x q[1];\n";
+        let circuit = parse(src).unwrap();
+        assert_eq!(
+            circuit.gates,
+            vec![Gate::Measure(0, 0), Gate::If(0, true, Box::new(Gate::X(1)))]
+        );
+    }
+
+    #[test]
+    fn parses_a_conditioned_gate_with_a_parameter() {
+        let src = "OPENQASM 2.0;\nqreg q[2];\ncreg c[1];\nif (c[0]==0) rz(0.5) q[1];\n";
+        let circuit = parse(src).unwrap();
+        assert_eq!(circuit.gates, vec![Gate::If(0, false, Box::new(Gate::Rz(1, 0.5)))]);
+    }
+
+    #[test]
+    fn parses_a_conditioned_two_qubit_gate() {
+        let src = "OPENQASM 2.0;\nqreg q[3];\ncreg c[1];\nif (c[0]==1) cx q[1], q[2];\n";
+        let circuit = parse(src).unwrap();
+        assert_eq!(circuit.gates, vec![Gate::If(0, true, Box::new(Gate::Cx(1, 2)))]);
+    }
+
+    #[test]
+    fn rejects_if_conditioning_a_measure() {
+        let src = "OPENQASM 2.0;\nqreg q[2];\ncreg c[1];\nif (c[0]==1) measure q[1] -> c[0];\n";
+        assert!(parse(src).is_err());
+    }
+
+    #[test]
+    fn rejects_nested_if() {
+        let src = "OPENQASM 2.0;\nqreg q[2];\ncreg c[1];\nif (c[0]==1) if (c[0]==0) x q[1];\n";
+        assert!(parse(src).is_err());
+    }
+
+    #[test]
+    fn rejects_if_condition_value_other_than_0_or_1() {
+        let src = "OPENQASM 2.0;\nqreg q[2];\ncreg c[1];\nif (c[0]==2) x q[1];\n";
+        assert!(parse(src).is_err());
+    }
+
+    #[test]
+    fn rejects_if_clbit_out_of_range() {
+        let src = "OPENQASM 2.0;\nqreg q[2];\ncreg c[1];\nif (c[5]==1) x q[1];\n";
+        assert!(parse(src).is_err());
+    }
+
+    #[test]
+    fn rejects_if_wrapping_a_qubit_out_of_range() {
+        let src = "OPENQASM 2.0;\nqreg q[2];\ncreg c[1];\nif (c[0]==1) x q[9];\n";
+        assert!(parse(src).is_err());
+    }
+
+    #[test]
+    fn rejects_malformed_if_missing_parens() {
+        let src = "OPENQASM 2.0;\nqreg q[2];\ncreg c[1];\nif c[0]==1 x q[1];\n";
+        assert!(parse(src).is_err());
+    }
+
+    #[test]
+    fn if_works_identically_under_qasm3_declarations() {
+        let src = "OPENQASM 3.0;\nqubit[2] q;\nbit[1] c;\nif (c[0]==1) x q[1];\n";
+        let circuit = parse(src).unwrap();
+        assert_eq!(circuit.gates, vec![Gate::If(0, true, Box::new(Gate::X(1)))]);
     }
 }

--- a/src/route.rs
+++ b/src/route.rs
@@ -2910,6 +2910,13 @@ fn remap_single(gate: &Gate, new_q: usize) -> Gate {
         // its classical bit `c` fixed and only moves the qubit -- `c`
         // is not a physical wire and routing never touches it.
         Measure(_, c) => Measure(new_q, c),
+        // `If`'s own qubit(s) are wherever `inner`'s are (see
+        // `Gate::qubits`), so remapping it means recursing into
+        // `inner` with the same `remap_single`/`remap_two` split the
+        // caller already used to get here -- `clbit`/`value` are
+        // classical, untouched by routing, same as `Measure`'s `c`
+        // above.
+        If(clbit, value, ref inner) => If(clbit, value, Box::new(remap_single(inner, new_q))),
         _ => unreachable!("remap_single called on a two-qubit gate"),
     }
 }
@@ -2924,6 +2931,9 @@ fn remap_two(gate: &Gate, new_first: usize, new_second: usize) -> Gate {
         Ryy(_, _, t) => Ryy(new_first, new_second, t),
         Rzz(_, _, t) => Rzz(new_first, new_second, t),
         Cp(_, _, l) => Cp(new_first, new_second, l),
+        If(clbit, value, ref inner) => {
+            If(clbit, value, Box::new(remap_two(inner, new_first, new_second)))
+        }
         _ => unreachable!("remap_two called on a single-qubit gate"),
     }
 }
@@ -2979,6 +2989,11 @@ mod tests {
                  (QuantumRegister::fidelity doesn't apply to a measured bit), not a variant \
                  of this direct-simulation comparison. None of this file's existing tests \
                  push a Measure gate, so this arm exists only to satisfy exhaustiveness."
+            ),
+            Gate::If(..) => panic!(
+                "apply_gate: If has no fidelity-based test yet, for the same reason as \
+                 Measure above. None of this file's existing tests push an If gate, so this \
+                 arm exists only to satisfy exhaustiveness."
             ),
         }
     }

--- a/tests/decompositions.rs
+++ b/tests/decompositions.rs
@@ -88,6 +88,14 @@ fn apply_ir_gate_directly(reg: &mut QuantumRegister, gate: &Gate) {
              to a measured bit), not this direct fidelity-comparison harness. No test in this \
              file exercises Measure; this arm exists only to satisfy exhaustiveness."
         ),
+        Gate::If(..) => panic!(
+            "apply_ir_gate_directly: If has no fidelity-based test yet, for the same reason \
+             as Measure above -- it reads a classical bit this direct fidelity-comparison \
+             harness has nowhere to produce. No test in this file exercises If; this arm \
+             exists only to satisfy exhaustiveness. (See emit.rs's \
+             apply_to_with_measurement/apply_native_gate_with_measurement for the real, \
+             tested execution path, and quantum_teleportation.rs for it in real use.)"
+        ),
     }
 }
 


### PR DESCRIPTION
## Add classical control to the IR: `Gate::If`

### Summary
Adds real classical-control support to the compiler IR, closing a gap `quantum_teleportation.rs` previously worked around by applying corrections by hand, directly against the `QuantumRegister`, outside the compiled circuit.

`Gate::If(clbit, value, Box<Gate>)` conditionally applies a gate based on a previously-measured classical bit, and is threaded through the full pipeline: parsing, optimization, decomposition, backend lowering, routing, execution, diagrams, and QASM export.

### What changed
- **`ir.rs`** — `Gate::If` + validation (rejects conditioning a `Measure`, rejects nested `If`, out-of-range clbits).
- **`ir_optimize.rs`** — `If` treated as a hard reorder barrier, same as `Measure`.
- **`native.rs` / `optimize.rs`** — `NativeGate::If`; a conditioned multi-gate source op (e.g. `H`) decomposes into multiple `If`-wrapped native gates, each carrying the same condition. Dropped `Copy` from `NativeGate`/`BackendGate` (a `Box` field can't be `Copy`) — fixed all call sites that relied on it.
- **`backend.rs`** — `BackendGate::If`; lowering wraps every physical gate a conditioned op re-expands to in the same condition; `optimize`/`resynthesize` treat it as a flush barrier.
- **`emit.rs`** — **actual execution**: checks the classical bit and conditionally applies the gate. This is the real replacement for the old by-hand correction.
- **`qasm.rs` / `emit.rs`** — round-trippable `if (c[N]==0|1) <stmt>;` text syntax (explicitly documented as a dialect extension — standard QASM only conditions on whole-creg equality).
- **`route.rs`** — qubit remapping recurses into `If`'s inner correctly.
- **`diagram.rs`** — renders as the wrapped gate's normal shape with an `IF c{n}=={0|1}:` label prefix.
- **`ibm_export.rs`** — errors explicitly rather than emitting incorrect QASM (no clean single-bit condition in real OpenQASM 2.0).
- **`pulse.rs`** — schedules the inner pulse statically, same as `Measure`; the runtime branch decision stays out of scope for this static model.
- **`quantum_teleportation.rs`** — rewritten to use `Gate::If` for Bob's correction instead of manual post-execution calls; the entire protocol is now one compiled circuit.

### Compatibility
Widens `NativeGate`/`BackendGate` from `Copy` to `Clone`-only. Any downstream code relying on implicit copies of these types will need `.clone()`.

### Testing
Unit tests added per module (validation, barrier/reorder behavior, decomposition, round-trip parsing). Not yet compiled against `sirraya_qutub` in this environment — please run `cargo check` before merging.