### PR TITLE
Add classical control, real-time execution, and hardware-realistic no…

### DIFF
--- a/examples/qiskit_benchmark.rs
+++ b/examples/qiskit_benchmark.rs
@@ -374,7 +374,7 @@ fn backend_gate_qubits(gate: &BackendGate) -> Vec<usize> {
     match gate {
         BackendGate::Rz(q, _) | BackendGate::Rot(q, _) | BackendGate::Measure(q, _) => vec![*q],
         BackendGate::Cx(a, b) | BackendGate::Cz(a, b) | BackendGate::Rzz(a, b, _) => vec![*a, *b],
-        BackendGate::If(_, _, inner) => backend_gate_qubits(inner),
+        BackendGate::If(_, inner) => backend_gate_qubits(inner),
     }
 }
 

--- a/examples/quantum_teleportation.rs
+++ b/examples/quantum_teleportation.rs
@@ -196,8 +196,8 @@ fn full_teleportation_circuit(prep: fn(&mut Circuit, usize)) -> Circuit {
     c.num_clbits = 2;
     c.push(Gate::Measure(0, 0)); // m0
     c.push(Gate::Measure(1, 1)); // m1
-    c.push(Gate::If(1, true, Box::new(Gate::X(2)))); // X iff m1 == 1
-    c.push(Gate::If(0, true, Box::new(Gate::Z(2)))); // Z iff m0 == 1
+    c.push(Gate::If(vec![(1, true)], Box::new(Gate::X(2)))); // X iff m1 == 1
+    c.push(Gate::If(vec![(0, true)], Box::new(Gate::Z(2)))); // Z iff m0 == 1
     c
 }
 

--- a/examples/resource_estimate_demo.rs
+++ b/examples/resource_estimate_demo.rs
@@ -1,0 +1,125 @@
+//! Fault-tolerant resource estimation: for a handful of circuits,
+//! prints the T-count / T-depth budget [`resource_estimate`] computes
+//! -- the number a fault-tolerant target is actually designed and
+//! rejected against, the same role [`fidelity_scaling`]'s NISQ-era
+//! depolarizing-error estimate plays for a near-term backend. See
+//! `resource_estimate.rs`'s own module doc for what this does and
+//! deliberately does not estimate (no physical qubit count, no code
+//! distance -- those need a real error-correcting code and a real
+//! target logical error rate, which this module has no opinion on).
+//!
+//! Run with: `cargo run --example resource_estimate_demo`
+
+use sirraya_qutub_transpiler::ir::{Circuit, Gate};
+use sirraya_qutub_transpiler::resource_estimate::{
+    estimate_circuit_resources, estimate_circuit_resources_with_epsilon, ResourceBudget,
+};
+
+/// H on qubit 0, then a CNOT ladder out to every other qubit -- the
+/// standard GHZ-state preparation circuit. Pure Clifford: every gate
+/// here (H, Cx) should cost exactly 0 T gates.
+fn ghz_circuit(num_qubits: usize) -> Circuit {
+    let mut c = Circuit::new(num_qubits);
+    c.push(Gate::H(0));
+    for q in 1..num_qubits {
+        c.push(Gate::Cx(0, q));
+    }
+    c
+}
+
+/// n-qubit Quantum Fourier Transform: H plus controlled-phase rotations
+/// with rapidly shrinking angles (`pi / 2^k`), then a reversal via
+/// Swaps. Interesting for this demo specifically because it's a mix:
+/// some of those angles land on exact Clifford+T points, most don't --
+/// so the reported budget is a genuine mix of `ExactT` and
+/// `Approximate` rotations, not one or the other.
+fn qft(n: usize) -> Circuit {
+    let mut c = Circuit::new(n);
+    for i in 0..n {
+        c.push(Gate::H(i));
+        for j in (i + 1)..n {
+            let lambda = std::f64::consts::PI / (1u32 << (j - i)) as f64;
+            c.push(Gate::Cp(j, i, lambda));
+        }
+    }
+    for i in 0..(n / 2) {
+        c.push(Gate::Swap(i, n - 1 - i));
+    }
+    c
+}
+
+fn print_budget(label: &str, budget: &ResourceBudget) {
+    println!(
+        "{:<28} T-count={:>6}  T-depth={:>5}  Clifford={:>6}  Measurements={:>3}  \
+         (exact rotations={}, approximated={})",
+        label,
+        budget.t_count,
+        budget.t_depth,
+        budget.clifford_count,
+        budget.measurement_count,
+        budget.exact_rotations,
+        budget.approximated_rotations,
+    );
+}
+
+fn main() {
+    println!("=== Pure Clifford circuits: T-count should be exactly 0 ===\n");
+    for n in [2usize, 8, 32] {
+        let budget = estimate_circuit_resources(&ghz_circuit(n));
+        print_budget(&format!("ghz_{n}"), &budget);
+        assert_eq!(budget.t_count, 0, "a pure-Clifford GHZ circuit must cost 0 T gates");
+    }
+
+    println!("\n=== One rotation at a time, showing each synthesis case ===\n");
+    let cases: [(&str, f64); 5] = [
+        ("Rz(0)              -- Identity", 0.0),
+        ("Rz(pi/2)           -- Clifford (S)", std::f64::consts::FRAC_PI_2),
+        ("Rz(pi/4)           -- ExactT (T)", std::f64::consts::FRAC_PI_4),
+        ("Rz(3*pi/4)         -- ExactT (Tdg up to Clifford)", 3.0 * std::f64::consts::FRAC_PI_4),
+        ("Rz(0.37)           -- Approximate (generic angle)", 0.37),
+    ];
+    for (label, angle) in cases {
+        let mut c = Circuit::new(1);
+        c.push(Gate::Rz(0, angle));
+        let budget = estimate_circuit_resources(&c);
+        print_budget(label, &budget);
+    }
+
+    println!("\n=== QFT: a realistic mix of exact and approximated rotations ===\n");
+    for n in [3usize, 5, 8] {
+        let budget = estimate_circuit_resources(&qft(n));
+        print_budget(&format!("qft_{n}"), &budget);
+    }
+
+    println!(
+        "\n(QFT's controlled-phase angles are pi/2^k for k = 1, 2, 3, ... -- k=1 (pi/2) and\n\
+         k=2 (pi/4) land on exact Clifford+T points once decomposed; every k >= 3 does not,\n\
+         so QFT's T-count grows both from more gates *and* a growing fraction of them needing\n\
+         the asymptotic estimate rather than an exact count, as n increases.)"
+    );
+
+    println!("\n=== Tightening the rotation precision epsilon raises T-count ===\n");
+    let mut single_rotation = Circuit::new(1);
+    single_rotation.push(Gate::Rz(0, 0.37));
+    for epsilon in [1e-3, 1e-6, 1e-10, 1e-15] {
+        let budget = estimate_circuit_resources_with_epsilon(&single_rotation, epsilon);
+        println!(
+            "  epsilon={:<8.0e}  T-count={:>3}  (Ross-Selinger: ~3*log2(1/epsilon))",
+            epsilon, budget.t_count
+        );
+    }
+
+    println!(
+        "\nThis is the fundamental fault-tolerant accuracy/cost trade-off: every digit of\n\
+         precision on a single arbitrary rotation costs real, additional T gates -- exactly\n\
+         why real fault-tolerant algorithm design tries hard to land on exact Clifford+T\n\
+         angles (multiples of pi/4) wherever the algorithm allows it, rather than leaving\n\
+         rotations at whatever angle falls out of a classical sub-routine unexamined."
+    );
+
+    // Sanity check consistent with resource_estimate.rs's own test
+    // suite: a tighter epsilon should never *reduce* the reported cost.
+    let loose = estimate_circuit_resources_with_epsilon(&single_rotation, 1e-3);
+    let tight = estimate_circuit_resources_with_epsilon(&single_rotation, 1e-15);
+    assert!(tight.t_count >= loose.t_count);
+}

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -94,7 +94,7 @@ mod rigetti;
 mod spec;
 mod trapped_ion;
 
-pub use spec::{Backend, BackendSpec, RotAxis};
+pub use spec::{Backend, BackendSpec, NativeTwoQubitGate, RotAxis};
 
 // NOTE: no longer `Copy` -- see `NativeGate`'s identical note; `If`'s
 // `Box<BackendGate>` field is the same kind of heap allocation that
@@ -122,22 +122,23 @@ pub enum BackendGate {
     /// identity in this module ever targets it.
     Measure(usize, usize),
     /// The backend-lowered counterpart of `ir::Gate::If` /
-    /// `native::NativeGate::If`: applies `inner` iff classical bit
-    /// `clbit` holds `value`. `lower`/`lower_with_coupling` produce it
-    /// by re-expressing a conditioned native gate exactly the way an
-    /// unconditioned one would be (via `push_ry`/`push_two_qubit_zz`/
-    /// direct `Rz`), then wrapping *every* `BackendGate` that
-    /// re-expansion emitted in the same condition -- so e.g. a
-    /// conditioned `Ry` lowered to an `Rx`-native backend becomes three
-    /// separately-conditioned `BackendGate`s (`Rot(pi/2)`,
-    /// `Rz(theta)`, `Rot(-pi/2)`, see [`push_ry_via_rx`]), not one `If`
-    /// wrapping all three -- the same reasoning `NativeGate::If`'s doc
-    /// comment gives for why that's the shape execution needs.
-    /// `inner` can be either 1- or 2-qubit-shaped depending on what got
-    /// re-expressed (e.g. an `Rx`-native backend's `push_two_qubit_zz`
-    /// identity for a conditioned `Rzz` produces conditioned `Cx`s, not
-    /// conditioned `Rzz`s) -- see [`BackendGate::qubits`].
-    If(usize, bool, Box<BackendGate>),
+    /// `native::NativeGate::If`: applies `inner` iff every
+    /// `(clbit, value)` pair in `conditions` holds. `lower`/
+    /// `lower_with_coupling` produce it by re-expressing a conditioned
+    /// native gate exactly the way an unconditioned one would be (via
+    /// `push_ry`/`push_two_qubit_zz`/direct `Rz`), then wrapping
+    /// *every* `BackendGate` that re-expansion emitted in the same
+    /// condition list -- so e.g. a conditioned `Ry` lowered to an
+    /// `Rx`-native backend becomes three separately-conditioned
+    /// `BackendGate`s (`Rot(pi/2)`, `Rz(theta)`, `Rot(-pi/2)`, see
+    /// [`push_ry_via_rx`]), not one `If` wrapping all three -- the same
+    /// reasoning `NativeGate::If`'s doc comment gives for why that's
+    /// the shape execution needs. `inner` can be either 1- or
+    /// 2-qubit-shaped depending on what got re-expressed (e.g. an
+    /// `Rx`-native backend's `push_two_qubit_zz` identity for a
+    /// conditioned `Rzz` produces conditioned `Cx`s, not conditioned
+    /// `Rzz`s) -- see [`BackendGate::qubits`].
+    If(Vec<(usize, bool)>, Box<BackendGate>),
 }
 
 impl BackendGate {
@@ -152,7 +153,7 @@ impl BackendGate {
             BackendGate::Cx(a, b) | BackendGate::Cz(a, b) | BackendGate::Rzz(a, b, _) => {
                 vec![a, b]
             }
-            BackendGate::If(_, _, ref inner) => inner.qubits(),
+            BackendGate::If(_, ref inner) => inner.qubits(),
         }
     }
 }
@@ -200,7 +201,7 @@ fn count_backend_gate(g: &BackendGate, single: &mut usize, two: &mut usize) {
         BackendGate::Rz(..) | BackendGate::Rot(..) => *single += 1,
         BackendGate::Cx(..) | BackendGate::Cz(..) | BackendGate::Rzz(..) => *two += 1,
         BackendGate::Measure(..) => {}
-        BackendGate::If(_, _, inner) => count_backend_gate(inner, single, two),
+        BackendGate::If(_, inner) => count_backend_gate(inner, single, two),
     }
 }
 
@@ -320,8 +321,8 @@ fn relabel_native_to_trapped_ion(g: &crate::native::NativeGate) -> BackendGate {
         NativeGate::Ry(q, a) => BackendGate::Rot(q, a),
         NativeGate::Rzz(a, b, t) => BackendGate::Rzz(a, b, t),
         NativeGate::Measure(q, c) => BackendGate::Measure(q, c),
-        NativeGate::If(clbit, value, ref inner) => {
-            BackendGate::If(clbit, value, Box::new(relabel_native_to_trapped_ion(inner)))
+        NativeGate::If(ref conditions, ref inner) => {
+            BackendGate::If(conditions.clone(), Box::new(relabel_native_to_trapped_ion(inner)))
         }
     }
 }
@@ -348,12 +349,12 @@ fn push_native_gate_reexpressed(
         NativeGate::Ry(q, a) => push_ry(bc, axis, q, a),
         NativeGate::Rzz(a, b, t) => backend.push_two_qubit_zz(bc, a, b, t),
         NativeGate::Measure(q, c) => bc.push(BackendGate::Measure(q, c)),
-        NativeGate::If(clbit, value, ref inner) => {
+        NativeGate::If(ref conditions, ref inner) => {
             let before = bc.gates.len();
             push_native_gate_reexpressed(bc, backend, axis, inner);
             let produced: Vec<BackendGate> = bc.gates.split_off(before);
             for produced_gate in produced {
-                bc.push(BackendGate::If(clbit, value, Box::new(produced_gate)));
+                bc.push(BackendGate::If(conditions.clone(), Box::new(produced_gate)));
             }
         }
     }
@@ -601,7 +602,7 @@ pub fn resynthesize(bc: &mut BackendCircuit) {
                 flush(q, &mut acc, &mut out, axis);
                 out.push(g);
             }
-            BackendGate::If(_, _, ref inner) => {
+            BackendGate::If(_, ref inner) => {
                 // Same treatment as Measure just above, generalized to
                 // every wire the conditioned gate touches (one or two,
                 // depending on what `inner` is -- see
@@ -876,7 +877,7 @@ pub fn optimize(bc: &mut BackendCircuit) {
                 invalidate_pairs_touching(&mut last_2q, q);
                 out.push(Some(g));
             }
-            BackendGate::If(_, _, ref inner) => {
+            BackendGate::If(_, ref inner) => {
                 // Same barrier treatment as Measure just above, over
                 // every wire `inner` touches (one or two -- see
                 // `BackendGate::qubits`): a conditioned gate is a real
@@ -1062,7 +1063,7 @@ mod tests {
                     // BackendGate::If's doc comment) still needs its
                     // adjacency checked, exactly as much as an
                     // unconditioned one would.
-                    BackendGate::If(_, _, ref inner) => match inner.as_ref() {
+                    BackendGate::If(_, ref inner) => match inner.as_ref() {
                         BackendGate::Cx(a, b) | BackendGate::Cz(a, b) => Some((*a, *b)),
                         BackendGate::Rzz(a, b, _) => Some((*a, *b)),
                         _ => None,

--- a/src/backend/google.rs
+++ b/src/backend/google.rs
@@ -103,4 +103,8 @@ impl BackendSpec for GoogleSpec {
         bc.push(BackendGate::Cz(control, target));
         push_h(bc, RotAxis::Rx, target);
     }
+
+    fn native_two_qubit_gate(&self) -> crate::backend::spec::NativeTwoQubitGate {
+        crate::backend::spec::NativeTwoQubitGate::FixedCz
+    }
 }

--- a/src/backend/ibmq.rs
+++ b/src/backend/ibmq.rs
@@ -53,4 +53,8 @@ impl BackendSpec for IbmQSpec {
     fn push_native_cx(&self, bc: &mut BackendCircuit, control: usize, target: usize) {
         bc.push(BackendGate::Cx(control, target));
     }
+
+    fn native_two_qubit_gate(&self) -> crate::backend::spec::NativeTwoQubitGate {
+        crate::backend::spec::NativeTwoQubitGate::FixedCx
+    }
 }

--- a/src/backend/rigetti.rs
+++ b/src/backend/rigetti.rs
@@ -66,4 +66,8 @@ impl BackendSpec for RigettiSpec {
         bc.push(BackendGate::Cz(control, target));
         push_h(bc, RotAxis::Rx, target);
     }
+
+    fn native_two_qubit_gate(&self) -> crate::backend::spec::NativeTwoQubitGate {
+        crate::backend::spec::NativeTwoQubitGate::FixedCz
+    }
 }

--- a/src/backend/spec.rs
+++ b/src/backend/spec.rs
@@ -54,6 +54,35 @@ pub enum RotAxis {
     Rx,
 }
 
+/// Which fixed physical interaction a `Channel::Control` pulse on this
+/// backend actually represents -- needed to invert a compiled
+/// [`crate::sequencer::Program`] back to the gate action it came from
+/// (see [`crate::sequencer::execute`]), since
+/// [`crate::pulse::PulseCalibration`]'s `two_qubit` table doesn't
+/// itself distinguish `Cx` from `Cz` -- both use the exact same fixed
+/// pulse shape in this crate's calibration model (see `pulse.rs`'s
+/// `push_leaf_pulse`, whose `Cx`/`Cz` match arm is shared). A required
+/// method, not a default, deliberately: a new `BackendSpec`
+/// implementation has to say which shape its native two-qubit
+/// interaction actually has rather than silently inheriting a wrong
+/// guess -- the same "no convenient default that could be wrong"
+/// judgment call [`BackendSpec::push_two_qubit_zz`] already makes by
+/// having no default at all.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NativeTwoQubitGate {
+    /// Continuously parameterized -- `TrappedIon`'s `Rzz`. A
+    /// `Channel::Control` pulse's amplitude directly encodes the
+    /// rotation angle (see this backend's `push_two_qubit_zz`).
+    ContinuousRzz,
+    /// A fixed-angle native `Cx` -- `IbmQ`. Every `Channel::Control`
+    /// pulse this backend emits is the same fixed gate, regardless of
+    /// amplitude (the amplitude field is present but uninformative --
+    /// see `pulse.rs`'s `push_leaf_pulse`).
+    FixedCx,
+    /// A fixed-angle native `Cz` -- `Rigetti`/`Google`.
+    FixedCz,
+}
+
 /// One physical backend's native gate set, connectivity, and
 /// calibration data. Implement this once per backend, in its own file,
 /// to add a new target for [`crate::backend::lower`] -- see this
@@ -155,6 +184,14 @@ pub trait BackendSpec: Send + Sync {
     fn is_native_decompose_target(&self) -> bool {
         false
     }
+
+    /// Which fixed physical interaction this backend's `Channel::Control`
+    /// pulses represent -- see [`NativeTwoQubitGate`]'s doc comment.
+    /// No default: every backend must say which of the three shapes
+    /// applies, since guessing wrong here would make
+    /// [`crate::sequencer::execute`] apply the wrong two-qubit gate
+    /// silently rather than erroring.
+    fn native_two_qubit_gate(&self) -> NativeTwoQubitGate;
 }
 
 /// A handle to one backend's [`BackendSpec`] implementation. `Copy`,
@@ -212,6 +249,9 @@ impl Backend {
     }
     pub(crate) fn is_native_decompose_target(self) -> bool {
         self.0.is_native_decompose_target()
+    }
+    pub fn native_two_qubit_gate(self) -> NativeTwoQubitGate {
+        self.0.native_two_qubit_gate()
     }
 }
 

--- a/src/backend/trapped_ion.rs
+++ b/src/backend/trapped_ion.rs
@@ -37,4 +37,8 @@ impl BackendSpec for TrappedIonSpec {
     fn is_native_decompose_target(&self) -> bool {
         true
     }
+
+    fn native_two_qubit_gate(&self) -> crate::backend::spec::NativeTwoQubitGate {
+        crate::backend::spec::NativeTwoQubitGate::ContinuousRzz
+    }
 }

--- a/src/diagram.rs
+++ b/src/diagram.rs
@@ -76,17 +76,23 @@ pub enum DiagramInstr {
 }
 
 /// Prefixes an already-built [`DiagramInstr`]'s display label(s) with
-/// `IF c{clbit}=={0|1}: `, for a gate that came from `Gate::If` /
-/// `NativeGate::If` / `BackendGate::If`. This crate's diagram model has
-/// no dedicated "conditional" shape -- the five variants above already
-/// cover every gate at every level (see this module's doc comment) --
-/// so a conditioned gate is drawn as exactly the same box/span/marker
-/// its unconditioned form would be, just labeled with the condition
-/// that gates it. This mirrors how vendor circuit diagrams usually
+/// `IF c0==0 && c1==1: ` (one `c{clbit}=={0|1}` per condition, joined
+/// with `&&`), for a gate that came from `Gate::If` / `NativeGate::If`
+/// / `BackendGate::If`. This crate's diagram model has no dedicated
+/// "conditional" shape -- the five variants above already cover every
+/// gate at every level (see this module's doc comment) -- so a
+/// conditioned gate is drawn as exactly the same box/span/marker its
+/// unconditioned form would be, just labeled with the condition(s)
+/// that gate it. This mirrors how vendor circuit diagrams usually
 /// render classical control in practice: an annotation on the existing
 /// box, not a new shape.
-fn prefix_instr_label(instr: DiagramInstr, clbit: usize, value: bool) -> DiagramInstr {
-    let prefix = format!("IF c{}=={}: ", clbit, value as u8);
+fn prefix_instr_label(instr: DiagramInstr, conditions: &[(usize, bool)]) -> DiagramInstr {
+    let condition_text = conditions
+        .iter()
+        .map(|&(clbit, value)| format!("c{}=={}", clbit, value as u8))
+        .collect::<Vec<_>>()
+        .join(" && ");
+    let prefix = format!("IF {}: ", condition_text);
     match instr {
         DiagramInstr::Single { qubit, label } => {
             DiagramInstr::Single { qubit, label: format!("{}{}", prefix, label) }
@@ -191,8 +197,8 @@ fn instr_for_gate(gate: &Gate) -> DiagramInstr {
         Gate::Rzz(a, b, t) => DiagramInstr::Span { qubits: (a, b), label: fmt_angle("RZZ", t) },
         Gate::Cp(c, t, l) => controlled(c, t, Some(fmt_angle("P", l))),
         Gate::Measure(q, c) => DiagramInstr::Measure { qubit: q, clbit: c },
-        Gate::If(clbit, value, ref inner) => {
-            prefix_instr_label(instr_for_gate(inner), clbit, value)
+        Gate::If(ref conditions, ref inner) => {
+            prefix_instr_label(instr_for_gate(inner), conditions)
         }
     }
 }
@@ -272,8 +278,8 @@ fn instr_for_native_gate(gate: &NativeGate) -> DiagramInstr {
         NativeGate::Ry(q, a) => DiagramInstr::Single { qubit: q, label: fmt_angle("RY", a) },
         NativeGate::Rzz(a, b, t) => DiagramInstr::Span { qubits: (a, b), label: fmt_angle("RZZ", t) },
         NativeGate::Measure(q, c) => DiagramInstr::Measure { qubit: q, clbit: c },
-        NativeGate::If(clbit, value, ref inner) => {
-            prefix_instr_label(instr_for_native_gate(inner), clbit, value)
+        NativeGate::If(ref conditions, ref inner) => {
+            prefix_instr_label(instr_for_native_gate(inner), conditions)
         }
     }
 }
@@ -291,8 +297,8 @@ fn instr_for_backend_gate(gate: &BackendGate, rot_axis: &str) -> DiagramInstr {
         BackendGate::Cz(a, b) => controlled(a, b, None),
         BackendGate::Rzz(a, b, t) => DiagramInstr::Span { qubits: (a, b), label: fmt_angle("RZZ", t) },
         BackendGate::Measure(q, c) => DiagramInstr::Measure { qubit: q, clbit: c },
-        BackendGate::If(clbit, value, ref inner) => {
-            prefix_instr_label(instr_for_backend_gate(inner, rot_axis), clbit, value)
+        BackendGate::If(ref conditions, ref inner) => {
+            prefix_instr_label(instr_for_backend_gate(inner, rot_axis), conditions)
         }
     }
 }

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -113,19 +113,31 @@ fn apply_native_gate_with_measurement(
             })?;
             *slot = outcome;
         }
-        NativeGate::If(clbit, value, ref inner) => {
+        NativeGate::If(ref conditions, ref inner) => {
             // This is the real thing `examples/quantum_teleportation.rs`
             // used to do by hand, directly against the `QuantumRegister`
             // after `emit::run` returned -- see that example's updated
             // doc comment for the before/after. `inner` is always a
             // bare Rz/Ry/Rzz (never Measure or another If -- see
             // `NativeGate::If`'s own doc comment), so this recursion
-            // bottoms out in exactly one more call.
+            // bottoms out in exactly one more call. Every condition in
+            // the list must hold (AND semantics -- see `ir::Gate::If`'s
+            // doc comment) for `inner` to fire.
             let num_clbits = clbits.len();
-            let outcome = *clbits.get(clbit).ok_or_else(|| {
-                format!("If reads classical bit {} but only {} were provided", clbit, num_clbits)
-            })?;
-            if (outcome != 0) == value {
+            let mut all_hold = true;
+            for &(clbit, value) in conditions {
+                let outcome = *clbits.get(clbit).ok_or_else(|| {
+                    format!(
+                        "If reads classical bit {} but only {} were provided",
+                        clbit, num_clbits
+                    )
+                })?;
+                if (outcome != 0) != value {
+                    all_hold = false;
+                    break;
+                }
+            }
+            if all_hold {
                 apply_native_gate_with_measurement(inner, reg, clbits)?;
             }
         }
@@ -141,12 +153,13 @@ fn apply_native_gate_with_measurement(
 /// emitters); everything else, including `If`, is identical between
 /// them.
 ///
-/// The `if (c[N]==0|1) <stmt>` syntax this emits for `NativeGate::If`
-/// is this crate's own dialect extension, the same kind of deliberate,
-/// documented departure from the standard `qasm.rs`'s module doc
-/// already notes for `rzz`/`ryy` -- real OPENQASM 2.0's `if` conditions
-/// on a whole `creg`'s *integer value*, not one indexed bit, and QASM
-/// 3.0 has no single-statement (non-block) `if` at all. `qasm::parse`'s
+/// The `if (c[N]==0|1 && c[M]==0|1 && ...) <stmt>` syntax this emits
+/// for `NativeGate::If` is this crate's own dialect extension, the
+/// same kind of deliberate, documented departure from the standard
+/// `qasm.rs`'s module doc already notes for `rzz`/`ryy` -- real
+/// OPENQASM 2.0's `if` conditions on a whole `creg`'s *integer value*,
+/// not a `&&`-joined list of indexed-bit equalities, and QASM 3.0 has
+/// no single-statement (non-block) `if` at all. `qasm::parse`'s
 /// `parse_if_condition` is the matching reader, so this still
 /// round-trips exactly the way every other statement here does.
 fn native_gate_stmt(gate: &NativeGate, measure_stmt: &dyn Fn(usize, usize) -> String) -> String {
@@ -155,12 +168,14 @@ fn native_gate_stmt(gate: &NativeGate, measure_stmt: &dyn Fn(usize, usize) -> St
         NativeGate::Ry(q, angle) => format!("ry({}) q[{}]", angle, q),
         NativeGate::Rzz(a, b, angle) => format!("rzz({}) q[{}], q[{}]", angle, a, b),
         NativeGate::Measure(q, c) => measure_stmt(q, c),
-        NativeGate::If(clbit, value, ref inner) => format!(
-            "if (c[{}]=={}) {}",
-            clbit,
-            value as u8,
-            native_gate_stmt(inner, measure_stmt)
-        ),
+        NativeGate::If(ref conditions, ref inner) => {
+            let condition_text = conditions
+                .iter()
+                .map(|&(clbit, value)| format!("c[{}]=={}", clbit, value as u8))
+                .collect::<Vec<_>>()
+                .join(" && ");
+            format!("if ({}) {}", condition_text, native_gate_stmt(inner, measure_stmt))
+        }
     }
 }
 
@@ -336,12 +351,22 @@ fn apply_backend_gate_with_measurement(
             })?;
             *slot = outcome;
         }
-        BackendGate::If(clbit, value, ref inner) => {
+        BackendGate::If(ref conditions, ref inner) => {
             let num_clbits = clbits.len();
-            let outcome = *clbits.get(clbit).ok_or_else(|| {
-                format!("If reads classical bit {} but only {} were provided", clbit, num_clbits)
-            })?;
-            if (outcome != 0) == value {
+            let mut all_hold = true;
+            for &(clbit, value) in conditions {
+                let outcome = *clbits.get(clbit).ok_or_else(|| {
+                    format!(
+                        "If reads classical bit {} but only {} were provided",
+                        clbit, num_clbits
+                    )
+                })?;
+                if (outcome != 0) != value {
+                    all_hold = false;
+                    break;
+                }
+            }
+            if all_hold {
                 apply_backend_gate_with_measurement(circuit, inner, reg, clbits)?;
             }
         }
@@ -410,7 +435,7 @@ mod qasm3_emit_tests {
         let mut nc = NativeCircuit::new(2);
         nc.num_clbits = 1;
         nc.push(NativeGate::Measure(0, 0));
-        nc.push(NativeGate::If(0, true, Box::new(NativeGate::Rz(1, 0.5))));
+        nc.push(NativeGate::If(vec![(0, true)], Box::new(NativeGate::Rz(1, 0.5))));
         nc
     }
 
@@ -428,7 +453,7 @@ mod qasm3_emit_tests {
             circuit.gates,
             vec![
                 crate::ir::Gate::Measure(0, 0),
-                crate::ir::Gate::If(0, true, Box::new(crate::ir::Gate::Rz(1, 0.5))),
+                crate::ir::Gate::If(vec![(0, true)], Box::new(crate::ir::Gate::Rz(1, 0.5))),
             ]
         );
     }

--- a/src/ibm_export.rs
+++ b/src/ibm_export.rs
@@ -153,16 +153,16 @@ pub fn lower_ibm_native(circuit: &BackendCircuit) -> Result<Vec<IbmInstr>, Strin
                     gate
                 ));
             }
-            BackendGate::If(clbit, ..) => {
+            BackendGate::If(ref conditions, ..) => {
                 return Err(format!(
-                    "lower_ibm_native: classically-conditioned gates (clbit {}) aren't \
+                    "lower_ibm_native: classically-conditioned gates (clbits {:?}) aren't \
                      supported yet -- real OPENQASM 2.0's `if` conditions on a whole creg's \
-                     integer value, not one indexed bit the way this crate's own qasm.rs \
-                     dialect extension does (see that module's `parse_if_condition` doc \
-                     comment); correctly expressing a single-bit condition in IBM's real \
-                     basis needs a convention this module doesn't have yet -- see this \
+                     integer value, not a list of indexed-bit equalities the way this crate's \
+                     own qasm.rs dialect extension does (see that module's \
+                     `parse_if_condition` doc comment); correctly expressing this in IBM's \
+                     real basis needs a convention this module doesn't have yet -- see this \
                      module's own doc comment.",
-                    clbit
+                    conditions.iter().map(|&(c, _)| c).collect::<Vec<_>>()
                 ));
             }
         }

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -93,31 +93,49 @@ pub enum Gate {
     /// `ir_optimize::disjoint` special-cases `Measure` to never commute
     /// past anything.
     Measure(usize, usize),
-    /// Applies `inner` iff classical bit `clbit` currently holds
-    /// `value` -- real, per-shot classical feed-forward control, not a
-    /// stand-in for it. This is the piece `examples/quantum_teleportation.rs`
-    /// used to work around by applying Bob's correction directly
-    /// against the `QuantumRegister` after `emit::run`, specifically
-    /// because this variant didn't exist yet -- see that example's own
-    /// doc comment (now updated) for the before/after.
+    /// Applies `inner` iff *every* `(clbit, value)` pair in the list
+    /// holds -- classical bits ANDed together, real per-shot classical
+    /// feed-forward control. A single-condition `If` (`conditions.len()
+    /// == 1`) is the common case -- teleportation's two corrections,
+    /// each depending on one measurement -- but this generalizes it to
+    /// real multi-bit joint conditions (e.g. a QEC syndrome correction
+    /// that depends on more than one stabilizer outcome at once),
+    /// which factoring into separate single-bit `If`s can't always
+    /// express. Real hardware/QASM3's own `if (c == N)` on a multi-bit
+    /// creg is exactly this: an AND over each bit of `N` against the
+    /// corresponding bit of `c`.
+    ///
+    /// This is the piece `examples/quantum_teleportation.rs` used to
+    /// work around by applying Bob's correction directly against the
+    /// `QuantumRegister` after `emit::run`, before `Gate::If` existed
+    /// at all -- see that example's own doc comment for the history.
     ///
     /// `inner` is always a single, concrete gate application, and
-    /// `Circuit::validate` enforces two shape restrictions on it:
-    /// - **Never `Measure`.** A measurement's whole job is to *produce*
-    ///   a classical bit; conditioning one on a classical bit has no
-    ///   physical meaning.
-    /// - **Never another `If`.** This stays a flat, one-level wrapper
-    ///   rather than an arbitrarily-recursive one -- every real use
-    ///   this crate has (teleportation's Bob-side correction, and any
-    ///   single conditioned gate a QASM `if` statement can express) is
-    ///   one condition on one gate.
+    /// `Circuit::validate` enforces real shape restrictions:
+    /// - **`conditions` is never empty.** A vacuous "always true"
+    ///   condition doesn't correspond to anything a real circuit would
+    ///   want to express -- if a gate should always fire, it shouldn't
+    ///   be wrapped in `If` at all.
+    /// - **No duplicate `clbit` within one `conditions` list.** Either
+    ///   redundant (`[(0,true),(0,true)]`) or outright contradictory
+    ///   and never satisfiable (`[(0,true),(0,false)]`) -- both signal
+    ///   a construction bug worth catching at validation time, the
+    ///   same judgment call already made for a two-qubit gate's
+    ///   self-targeting.
+    /// - **`inner` is never `Measure`.** A measurement's whole job is
+    ///   to *produce* a classical bit; conditioning one on a classical
+    ///   bit has no physical meaning.
+    /// - **`inner` is never another `If`.** This stays a flat,
+    ///   one-level wrapper (with however many conditions it needs)
+    ///   rather than an arbitrarily-recursive one.
     ///
-    /// `native::decompose_gate` distributes the condition across every
-    /// native gate `inner` decomposes to (e.g. a conditioned `H` becomes
-    /// a conditioned `Rz`/`Ry`/`Rz` triple, each wrapped in its own
-    /// `NativeGate::If` with the same `clbit`/`value`), so a caller
-    /// never needs to build a nested `If` even for a multi-gate `inner`.
-    If(usize, bool, Box<Gate>),
+    /// `native::decompose_gate` distributes the *whole condition list*
+    /// across every native gate `inner` decomposes to (e.g. a
+    /// conditioned `H` becomes a conditioned `Rz`/`Ry`/`Rz` triple,
+    /// each wrapped in its own `NativeGate::If` with the same
+    /// `conditions`), so a caller never needs to build a nested `If`
+    /// even for a multi-gate `inner`.
+    If(Vec<(usize, bool)>, Box<Gate>),
 }
 
 impl Gate {
@@ -137,7 +155,7 @@ impl Gate {
             | Rz(q, _) | Measure(q, _) => vec![q],
             Cx(a, b) | Cz(a, b) | Swap(a, b) | Rxx(a, b, _) | Ryy(a, b, _) | Rzz(a, b, _)
             | Cp(a, b, _) => vec![a, b],
-            If(_, _, ref inner) => inner.qubits(),
+            If(_, ref inner) => inner.qubits(),
         }
     }
 }
@@ -233,13 +251,14 @@ impl Circuit {
     /// arity mismatch a compile error, not a runtime one -- there is
     /// no way to construct an ill-formed `Gate` in the first
     /// place, so a runtime check would only ever be dead code.
-    /// 5. **`If`'s own shape.** Its classical bit index is `< self.num_clbits`,
-    ///    and its `inner` gate is neither `Measure` (see `Gate::If`'s
-    ///    doc comment on why that has no meaning) nor another `If`
-    ///    (this stays a flat, one-level wrapper). `inner` itself is
-    ///    then checked against every rule above, recursively -- so a
-    ///    conditioned `Cx(0, 0)` or a conditioned `NaN` angle is caught
-    ///    exactly as it would be unconditioned.
+    /// 5. **`If`'s own shape.** `conditions` is non-empty, has no
+    ///    duplicate `clbit` within it, and every `clbit` is
+    ///    `< self.num_clbits`; its `inner` gate is neither `Measure`
+    ///    (see `Gate::If`'s doc comment on why that has no meaning) nor
+    ///    another `If` (this stays a flat, one-level wrapper). `inner`
+    ///    itself is then checked against every rule above, recursively
+    ///    -- so a conditioned `Cx(0, 0)` or a conditioned `NaN` angle
+    ///    is caught exactly as it would be unconditioned.
     pub fn validate(&self) -> Result<(), String> {
         for (i, gate) in self.gates.iter().enumerate() {
             self.validate_gate(i, gate)?;
@@ -291,12 +310,31 @@ impl Circuit {
                 ));
             }
         }
-        if let Gate::If(clbit, _, ref inner) = *gate {
-            if clbit >= self.num_clbits {
+        if let Gate::If(ref conditions, ref inner) = *gate {
+            if conditions.is_empty() {
                 return Err(format!(
-                    "gate {} ({:?}): If's classical bit index {} out of range for {} clbit(s)",
-                    i, gate, clbit, self.num_clbits
+                    "gate {} ({:?}): If must have at least one (clbit, value) condition -- a \
+                     vacuous, always-true If doesn't correspond to anything a real circuit \
+                     should express",
+                    i, gate
                 ));
+            }
+            for (idx, &(clbit, _)) in conditions.iter().enumerate() {
+                if clbit >= self.num_clbits {
+                    return Err(format!(
+                        "gate {} ({:?}): If's classical bit index {} out of range for {} \
+                         clbit(s)",
+                        i, gate, clbit, self.num_clbits
+                    ));
+                }
+                if conditions[..idx].iter().any(|&(c, _)| c == clbit) {
+                    return Err(format!(
+                        "gate {} ({:?}): If's conditions reference classical bit {} more than \
+                         once -- either redundant or contradictory, both signal a construction \
+                         bug rather than something a real circuit should express",
+                        i, gate, clbit
+                    ));
+                }
             }
             match inner.as_ref() {
                 Gate::Measure(..) => {
@@ -309,7 +347,8 @@ impl Circuit {
                 Gate::If(..) => {
                     return Err(format!(
                         "gate {} ({:?}): If cannot condition another If -- nested classical \
-                         conditions aren't supported here, flatten to a single condition",
+                         conditions aren't supported here, flatten to a single If with every \
+                         condition in one list",
                         i, gate
                     ));
                 }
@@ -435,27 +474,81 @@ mod tests {
     #[test]
     fn if_qubits_delegates_to_inner() {
         // A single-qubit inner...
-        assert_eq!(Gate::If(0, true, Box::new(Gate::X(2))).qubits(), vec![2]);
+        assert_eq!(Gate::If(vec![(0, true)], Box::new(Gate::X(2))).qubits(), vec![2]);
         // ...and a two-qubit inner, unchanged from what `route.rs`/
         // `ir_optimize.rs` need to place/reorder it correctly with no
         // `Gate::If`-specific case of their own (see `qubits`'s doc
         // comment).
-        assert_eq!(Gate::If(0, true, Box::new(Gate::Cx(1, 3))).qubits(), vec![1, 3]);
+        assert_eq!(
+            Gate::If(vec![(0, true)], Box::new(Gate::Cx(1, 3))).qubits(),
+            vec![1, 3]
+        );
+        // A multi-condition If still delegates to inner the same way --
+        // qubits() doesn't care how many conditions gate it.
+        assert_eq!(
+            Gate::If(vec![(0, true), (1, false)], Box::new(Gate::X(2))).qubits(),
+            vec![2]
+        );
     }
 
     #[test]
     fn accepts_well_formed_if() {
         let mut c = Circuit::new(2);
         c.num_clbits = 1;
-        c.push(Gate::Measure(0, 0)).push(Gate::If(0, true, Box::new(Gate::X(1))));
+        c.push(Gate::Measure(0, 0)).push(Gate::If(vec![(0, true)], Box::new(Gate::X(1))));
         assert!(c.validate().is_ok());
+    }
+
+    #[test]
+    fn accepts_a_genuine_multi_condition_if() {
+        let mut c = Circuit::new(3);
+        c.num_clbits = 2;
+        c.push(Gate::Measure(0, 0))
+            .push(Gate::Measure(1, 1))
+            .push(Gate::If(vec![(0, true), (1, true)], Box::new(Gate::X(2))));
+        assert!(c.validate().is_ok());
+    }
+
+    #[test]
+    fn rejects_if_with_no_conditions() {
+        let mut c = Circuit::new(2);
+        c.num_clbits = 1;
+        c.push(Gate::If(vec![], Box::new(Gate::X(1))));
+        assert!(c.validate().is_err());
     }
 
     #[test]
     fn rejects_if_clbit_out_of_range() {
         let mut c = Circuit::new(2);
         c.num_clbits = 1;
-        c.push(Gate::If(5, true, Box::new(Gate::X(1))));
+        c.push(Gate::If(vec![(5, true)], Box::new(Gate::X(1))));
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_if_with_one_valid_and_one_out_of_range_clbit() {
+        // Every condition must be checked, not just the first.
+        let mut c = Circuit::new(2);
+        c.num_clbits = 1;
+        c.push(Gate::If(vec![(0, true), (5, false)], Box::new(Gate::X(1))));
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_if_referencing_the_same_clbit_twice_with_the_same_value() {
+        // Redundant, not just contradictory -- still a real construction
+        // bug worth catching.
+        let mut c = Circuit::new(2);
+        c.num_clbits = 1;
+        c.push(Gate::If(vec![(0, true), (0, true)], Box::new(Gate::X(1))));
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_if_referencing_the_same_clbit_twice_with_contradictory_values() {
+        let mut c = Circuit::new(2);
+        c.num_clbits = 1;
+        c.push(Gate::If(vec![(0, true), (0, false)], Box::new(Gate::X(1))));
         assert!(c.validate().is_err());
     }
 
@@ -463,7 +556,7 @@ mod tests {
     fn rejects_if_conditioning_a_measure() {
         let mut c = Circuit::new(2);
         c.num_clbits = 1;
-        c.push(Gate::If(0, true, Box::new(Gate::Measure(1, 0))));
+        c.push(Gate::If(vec![(0, true)], Box::new(Gate::Measure(1, 0))));
         assert!(c.validate().is_err());
     }
 
@@ -471,7 +564,10 @@ mod tests {
     fn rejects_nested_if() {
         let mut c = Circuit::new(2);
         c.num_clbits = 1;
-        c.push(Gate::If(0, true, Box::new(Gate::If(0, false, Box::new(Gate::X(1))))));
+        c.push(Gate::If(
+            vec![(0, true)],
+            Box::new(Gate::If(vec![(0, false)], Box::new(Gate::X(1)))),
+        ));
         assert!(c.validate().is_err());
     }
 
@@ -481,7 +577,7 @@ mod tests {
         // through the wrapper.
         let mut c = Circuit::new(2);
         c.num_clbits = 1;
-        c.push(Gate::If(0, true, Box::new(Gate::X(9))));
+        c.push(Gate::If(vec![(0, true)], Box::new(Gate::X(9))));
         assert!(c.validate().is_err());
     }
 
@@ -489,7 +585,7 @@ mod tests {
     fn rejects_if_wrapping_a_nan_angle() {
         let mut c = Circuit::new(1);
         c.num_clbits = 1;
-        c.push(Gate::If(0, true, Box::new(Gate::Rz(0, f64::NAN))));
+        c.push(Gate::If(vec![(0, true)], Box::new(Gate::Rz(0, f64::NAN))));
         assert!(c.validate().is_err());
     }
 
@@ -497,7 +593,7 @@ mod tests {
     fn rejects_if_wrapping_a_self_targeting_two_qubit_gate() {
         let mut c = Circuit::new(2);
         c.num_clbits = 1;
-        c.push(Gate::If(0, true, Box::new(Gate::Cx(0, 0))));
+        c.push(Gate::If(vec![(0, true)], Box::new(Gate::Cx(0, 0))));
         assert!(c.validate().is_err());
     }
 
@@ -505,7 +601,7 @@ mod tests {
     fn if_counts_under_its_own_mnemonic() {
         let mut c = Circuit::new(1);
         c.num_clbits = 1;
-        c.push(Gate::If(0, true, Box::new(Gate::X(0))));
+        c.push(Gate::If(vec![(0, true)], Box::new(Gate::X(0))));
         assert_eq!(c.gate_counts().get("if"), Some(&1));
     }
 }

--- a/src/ir_optimize.rs
+++ b/src/ir_optimize.rs
@@ -508,7 +508,7 @@ mod tests {
         // look swappable, but an If must never be slid past anything.
         let mut c = Circuit::new(3);
         c.num_clbits = 1;
-        let if_gate = Gate::If(0, true, Box::new(Gate::X(1)));
+        let if_gate = Gate::If(vec![(0, true)], Box::new(Gate::X(1)));
         c.push(if_gate.clone()).push(Gate::X(2));
         let opt = optimize_ir(&c);
         assert_eq!(opt.gates, vec![if_gate, Gate::X(2)]);
@@ -523,7 +523,7 @@ mod tests {
         let mut c = Circuit::new(2);
         c.num_clbits = 1;
         let measure = Gate::Measure(0, 0);
-        let if_gate = Gate::If(0, true, Box::new(Gate::X(1)));
+        let if_gate = Gate::If(vec![(0, true)], Box::new(Gate::X(1)));
         c.push(measure.clone()).push(if_gate.clone());
         let opt = optimize_ir(&c);
         assert_eq!(opt.gates, vec![measure, if_gate]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,59 @@
 //! relative to the rest of the pipeline, nothing above it needs to
 //! change, or even know it exists.
 //!
+//! [`sequencer::compile`] sits below `pulse` a different way: rather
+//! than going deeper into single-pulse physics the way `waveform_sim`
+//! does, it goes sideways into real-time *control flow* -- turning an
+//! already-lowered [`BackendCircuit`] (containing a
+//! [`BackendGate::If`]) into a branching [`sequencer::Program`] with
+//! real registers and real jumps, the layer `pulse::Schedule`'s own
+//! flat, unconditional instruction list deliberately doesn't attempt
+//! (see `pulse.rs`'s own `BackendGate::If` handling, and
+//! `sequencer.rs`'s module doc for the full rationale). This is the
+//! layer a real control-electronics backend (Quantum Machines, Zurich
+//! Instruments, Keysight, or a lab's own custom stack) would target;
+//! [`sequencer::HardwareTarget`] is the open extension point for one,
+//! mirroring [`backend::BackendSpec`]'s one-trait-per-vendor pattern --
+//! no implementation ships in this crate yet, since guessing at a
+//! specific vendor's real instruction set isn't something this crate
+//! does (see that module's doc comment).
+//!
+//! [`readout`] is a different kind of noise from anything else above:
+//! not a gate-error or pulse-fidelity budget, but the classical
+//! confusion between a qubit's true, exactly-collapsed measurement
+//! outcome and what a real (imperfect) readout chain actually reports.
+//! [`sequencer::execute_with_readout_noise`] is where it plugs in --
+//! applied to exactly the classical bit `Gate::If`/`SeqInstr::JumpIfEqual`
+//! branch on, so a corrupted readout can make a conditioned correction
+//! fire (or not) based on the wrong bit, even though the underlying
+//! quantum collapse stayed exact. See `readout.rs`'s own doc comment
+//! for why this is modeled as an independent, purely classical layer
+//! rather than folded into any other noise source in this crate.
+//!
+//! [`noise`] is the gate-error counterpart: real, per-gate depolarizing
+//! noise sampled from [`fidelity::PublishedCalibration`]'s existing
+//! cited numbers (the same ones `fidelity::estimate_circuit_fidelity`
+//! already uses for its own aggregate survival-probability estimate,
+//! now made sampleable rather than only summarized). Every example in
+//! this crate that needed a genuinely noisy run used to hand-roll its
+//! own ad hoc version of this at the example level -- see `noise.rs`'s
+//! own doc comment for why that stopped being the right call once
+//! `sequencer::execute_with_noise` needed the same thing in the
+//! library itself, combined with [`readout`] noise in one place.
+//!
+//! [`resource_estimate`] is a separate, additive concern from
+//! everything above: it never touches `sirraya_qutub` at all (it's
+//! pure counting over an [`ir::Circuit`], via [`native::decompose`] +
+//! [`optimize::optimize`]), and estimates a *fault-tolerant* resource
+//! budget (T-count, T-depth) rather than [`fidelity`]'s NISQ-era
+//! depolarizing-error budget. It exists because "how many T gates does
+//! this circuit need" is the number a fault-tolerant target actually
+//! gets designed and rejected against, the way `fidelity`'s estimate
+//! already serves that role for NISQ backends -- see its own module
+//! doc for what it does and deliberately does not estimate (physical
+//! qubit count and code distance are real, separate, hardware-specific
+//! follow-on work).
+//!
 //! [`backend::Backend`] is an open extension point, not a fixed list:
 //! it's a handle onto a [`backend::BackendSpec`] implementation,
 //! and each of the three backends shipped today
@@ -65,10 +118,14 @@ pub mod ibm_export;
 pub mod ir;
 pub mod ir_optimize;
 pub mod native;
+pub mod noise;
 pub mod optimize;
 pub mod pulse;
 pub mod qasm;
+pub mod readout;
+pub mod resource_estimate;
 pub mod route;
+pub mod sequencer;
 pub mod waveform_sim;
 
 pub use backend::{lower, lower_with_coupling, lower_no_restore, lower_with_coupling_no_restore, Backend, BackendCircuit, BackendGate, BackendSpec, RotAxis};
@@ -84,9 +141,16 @@ pub use pulse::{
     PulseInstruction, Schedule, SingleQubitPulseCalibration, TwoQubitContinuousPulseCalibration,
     TwoQubitPulseCalibration,
 };
+pub use sequencer::{compile as compile_sequencer, execute as execute_sequencer, HardwareTarget, Program, SeqInstr};
+pub use readout::{corrupt_readout, ReadoutCalibration};
+pub use noise::{apply_pauli_error, sample_depolarizing_error, PauliError};
 pub use fidelity::{estimate_circuit_fidelity, PublishedCalibration};
 pub use route::{route, route_lookahead, route_sabre, route_best, route_best_no_restore, route_qft, restoration_swap_count};
 pub use ibm_export::{to_ibm_qasm, lower_ibm_native, validate_cx_native_basis, IbmInstr};
 pub use waveform_sim::{
     integrate, rotation_angle_rad, BlochVector, RABI_RATE_PER_UNIT_AMPLITUDE_RAD_PER_NS,
+};
+pub use resource_estimate::{
+    estimate_circuit_resources, estimate_circuit_resources_with_epsilon, ResourceBudget,
+    RotationSynthesis, DEFAULT_ROTATION_EPSILON,
 };

--- a/src/native.rs
+++ b/src/native.rs
@@ -33,20 +33,20 @@ pub enum NativeGate {
     /// side of any decomposition identity in this module.
     Measure(usize, usize),
     /// The native-level counterpart of `ir::Gate::If`: applies `inner`
-    /// iff classical bit `clbit` holds `value`. Produced by
-    /// `decompose_gate` distributing a source-level `If`'s condition
-    /// across every native gate its `inner` decomposes to -- so a
-    /// conditioned `H`, for instance, becomes a conditioned
+    /// iff every `(clbit, value)` pair in `conditions` holds. Produced
+    /// by `decompose_gate` distributing a source-level `If`'s whole
+    /// condition list across every native gate its `inner` decomposes
+    /// to -- so a conditioned `H`, for instance, becomes a conditioned
     /// `Rz`/`Ry`/`Rz` triple (three separate `NativeGate::If`s, same
-    /// `clbit`/`value` on each), not one `If` wrapping all three. That
+    /// `conditions` on each), not one `If` wrapping all three. That
     /// shape is what `emit.rs` actually needs to execute correctly: a
     /// physical pulse either fires or it doesn't, one at a time, and
-    /// each one independently depends on the same classical bit.
+    /// each one independently depends on the same classical bits.
     /// `inner` is always a bare `Rz`/`Ry`/`Rzz` -- never `Measure` or
     /// another `If`, same restriction as `ir::Gate::If` (enforced there
     /// by `Circuit::validate`, before decomposition ever runs, so it
     /// isn't re-checked here).
-    If(usize, bool, Box<NativeGate>),
+    If(Vec<(usize, bool)>, Box<NativeGate>),
 }
 
 #[derive(Debug, Clone, Default)]
@@ -101,7 +101,7 @@ fn count_gate(g: &NativeGate, single: &mut usize, two: &mut usize) {
         NativeGate::Rz(..) | NativeGate::Ry(..) => *single += 1,
         NativeGate::Rzz(..) => *two += 1,
         NativeGate::Measure(..) => {}
-        NativeGate::If(_, _, inner) => count_gate(inner, single, two),
+        NativeGate::If(_, inner) => count_gate(inner, single, two),
     }
 }
 
@@ -306,13 +306,13 @@ pub fn decompose(circuit: &Circuit) -> NativeCircuit {
 pub(crate) fn decompose_gate(nc: &mut NativeCircuit, gate: &Gate) {
     match *gate {
         Gate::Measure(q, c) => nc.push(NativeGate::Measure(q, c)),
-        Gate::If(clbit, value, ref inner) => {
+        Gate::If(ref conditions, ref inner) => {
             // `inner` is decomposed on its own into a fresh scratch
             // circuit first (never Measure or another If -- see
             // `ir::Gate::If`'s doc comment and `Circuit::validate`,
             // which rejects both before this ever runs), then every
             // native gate that decomposition produced is wrapped in the
-            // same condition. A single source-level `If(H)` becoming
+            // same condition list. A single source-level `If(H)` becoming
             // three separately-conditioned native gates (Rz/Ry/Rz, one
             // `NativeGate::If` each) rather than one `If` wrapping all
             // three is deliberate -- see `NativeGate::If`'s own doc
@@ -320,7 +320,7 @@ pub(crate) fn decompose_gate(nc: &mut NativeCircuit, gate: &Gate) {
             let mut tmp = NativeCircuit::new(nc.num_qubits);
             decompose_gate(&mut tmp, inner);
             for g in tmp.gates {
-                nc.push(NativeGate::If(clbit, value, Box::new(g)));
+                nc.push(NativeGate::If(conditions.clone(), Box::new(g)));
             }
         }
         Gate::H(q) => push_single(nc, q, m_h()),
@@ -444,30 +444,46 @@ mod if_decompose_tests {
     fn decomposes_a_conditioned_single_native_gate_into_one_wrapped_if() {
         let mut c = Circuit::new(1);
         c.num_clbits = 1;
-        c.push(Gate::If(0, true, Box::new(Gate::Rz(0, 0.5))));
+        c.push(Gate::If(vec![(0, true)], Box::new(Gate::Rz(0, 0.5))));
         let nc = decompose(&c);
         assert_eq!(
             nc.gates,
-            vec![NativeGate::If(0, true, Box::new(NativeGate::Rz(0, 0.5)))]
+            vec![NativeGate::If(vec![(0, true)], Box::new(NativeGate::Rz(0, 0.5)))]
         );
     }
 
     #[test]
     fn decomposes_a_conditioned_multi_gate_source_gate_into_one_wrapped_if_per_native_gate() {
         // H decomposes to an Rz/Ry/Rz triple (see push_single) -- every
-        // one of those three must carry the *same* condition, not just
-        // the first (see NativeGate::If's doc comment).
+        // one of those three must carry the *same* condition list, not
+        // just the first (see NativeGate::If's doc comment).
         let mut c = Circuit::new(1);
         c.num_clbits = 1;
-        c.push(Gate::If(2, false, Box::new(Gate::H(0))));
+        c.push(Gate::If(vec![(2, false)], Box::new(Gate::H(0))));
         let nc = decompose(&c);
         assert!(!nc.gates.is_empty());
         for g in &nc.gates {
             match g {
-                NativeGate::If(clbit, value, inner) => {
-                    assert_eq!(*clbit, 2);
-                    assert_eq!(*value, false);
+                NativeGate::If(conditions, inner) => {
+                    assert_eq!(conditions.as_slice(), &[(2, false)]);
                     assert!(matches!(inner.as_ref(), NativeGate::Rz(..) | NativeGate::Ry(..)));
+                }
+                other => panic!("expected every native gate to be If-wrapped, got {:?}", other),
+            }
+        }
+    }
+
+    #[test]
+    fn decomposes_a_multi_condition_if_preserving_every_condition_on_every_native_gate() {
+        let mut c = Circuit::new(1);
+        c.num_clbits = 2;
+        c.push(Gate::If(vec![(0, true), (1, false)], Box::new(Gate::H(0))));
+        let nc = decompose(&c);
+        assert!(!nc.gates.is_empty());
+        for g in &nc.gates {
+            match g {
+                NativeGate::If(conditions, _) => {
+                    assert_eq!(conditions.as_slice(), &[(0, true), (1, false)]);
                 }
                 other => panic!("expected every native gate to be If-wrapped, got {:?}", other),
             }
@@ -477,7 +493,7 @@ mod if_decompose_tests {
     #[test]
     fn gate_counts_prices_a_conditioned_rotation_the_same_as_an_unconditioned_one() {
         let mut conditioned = NativeCircuit::new(1);
-        conditioned.push(NativeGate::If(0, true, Box::new(NativeGate::Rz(0, 0.1))));
+        conditioned.push(NativeGate::If(vec![(0, true)], Box::new(NativeGate::Rz(0, 0.1))));
         let mut plain = NativeCircuit::new(1);
         plain.push(NativeGate::Rz(0, 0.1));
         assert_eq!(conditioned.gate_counts(), plain.gate_counts());
@@ -487,7 +503,7 @@ mod if_decompose_tests {
     #[test]
     fn gate_counts_prices_a_conditioned_two_qubit_gate_as_two_qubit() {
         let mut nc = NativeCircuit::new(2);
-        nc.push(NativeGate::If(0, true, Box::new(NativeGate::Rzz(0, 1, 0.2))));
+        nc.push(NativeGate::If(vec![(0, true)], Box::new(NativeGate::Rzz(0, 1, 0.2))));
         assert_eq!(nc.gate_counts(), (0, 1));
     }
 }

--- a/src/noise.rs
+++ b/src/noise.rs
@@ -1,0 +1,124 @@
+//! Gate-level depolarizing noise, sampled from this crate's own cited
+//! error-rate numbers (`fidelity::PublishedCalibration`) rather than
+//! each caller re-deriving or re-guessing its own noise model.
+//!
+//! # Why this didn't exist as a library module before
+//! `fidelity::estimate_circuit_fidelity`/`estimate_backend_circuit_fidelity`
+//! already treat each native gate's error as an independent
+//! depolarizing event -- but only to multiply survival probabilities
+//! into a single aggregate number, never to actually *sample* a noisy
+//! trajectory. Every example in this crate that needed a genuinely
+//! noisy run (`quantum_teleportation.rs` among them) ended up
+//! hand-rolling its own ad hoc Pauli-kick injection at the example
+//! level, each with its own slightly different simplification, none
+//! of them reusing `PublishedCalibration`'s already-cited single-/
+//! two-qubit error rates for the actual sampling. This module is that
+//! shared, real implementation: the same numbers `fidelity.rs` already
+//! cites, now sampleable, in one place.
+//!
+//! # The model
+//! A standard single-qubit depolarizing channel: with probability `p`
+//! (split evenly three ways), apply one of `X`/`Y`/`Z`; with
+//! probability `1 - p`, do nothing. For a two-qubit gate, this module
+//! applies that same single-qubit channel *independently* to each of
+//! the two qubits involved, each at the two-qubit error probability --
+//! a standard, simplified stand-in for a full two-qubit depolarizing
+//! channel (which would need sampling among 15 nontrivial two-qubit
+//! Pauli combinations, not just 3), consistent with the level of
+//! simplification `fidelity.rs`'s own aggregate estimate already
+//! accepts (see that module's doc comment: "the standard first-order
+//! approximation ... not a substitute for actually running XEB").
+//!
+//! [`crate::sequencer::execute_with_noise`] only samples this for a
+//! real physical pulse (`Channel::Drive`/`Channel::Control` `Play`
+//! instructions) -- never for a virtual-Z `ShiftPhase`. That's a
+//! deliberate, more physically precise choice than
+//! `fidelity::estimate_circuit_fidelity`'s own gate-counting (which
+//! prices `Rz` the same as `Ry` purely for the simplicity of a quick
+//! sanity-check number): a virtual-Z frame update has essentially zero
+//! real gate error on real hardware, which is the entire point of
+//! implementing it that way rather than as a physical pulse. The two
+//! modules disagreeing here is expected, not a bug -- see
+//! `sequencer.rs`'s own doc comment on `execute_with_noise` for the
+//! explicit note.
+//!
+//! # Why this crate's library code takes randomness as a parameter
+//! Same reasoning as `readout.rs`: this crate's `[dependencies]` has
+//! no RNG crate, only `[dev-dependencies]` does. [`sample_depolarizing_error`]
+//! is a pure function of an already-drawn `f64 in [0, 1)`, not
+//! something that draws its own randomness.
+
+use sirraya_qutub::core::QuantumRegister;
+
+/// Which single-qubit Pauli error a depolarizing-noise sample
+/// selected. No `None`/identity variant -- [`sample_depolarizing_error`]
+/// returns `Option<PauliError>` instead, so "no error occurred" is
+/// `None`, not a fourth variant here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PauliError {
+    X,
+    Y,
+    Z,
+}
+
+/// Samples a single-qubit depolarizing-channel outcome: with
+/// probability `p` (split evenly three ways: `[0, p/3)` -> `X`,
+/// `[p/3, 2p/3)` -> `Y`, `[2p/3, p)` -> `Z`), returns the corresponding
+/// error; otherwise (`[p, 1)`) returns `None`. Pure and deterministic
+/// given `uniform_sample` -- see this module's doc comment.
+pub fn sample_depolarizing_error(p: f64, uniform_sample: f64) -> Option<PauliError> {
+    if uniform_sample < p / 3.0 {
+        Some(PauliError::X)
+    } else if uniform_sample < 2.0 * p / 3.0 {
+        Some(PauliError::Y)
+    } else if uniform_sample < p {
+        Some(PauliError::Z)
+    } else {
+        None
+    }
+}
+
+/// Applies `err` to qubit `q` of `reg` -- the real, physical
+/// consequence of a [`sample_depolarizing_error`] draw that returned
+/// `Some`.
+pub fn apply_pauli_error(reg: &mut QuantumRegister, q: usize, err: PauliError) -> Result<(), String> {
+    match err {
+        PauliError::X => reg.apply_pauli_x(q),
+        PauliError::Y => reg.apply_pauli_y(q),
+        PauliError::Z => reg.apply_pauli_z(q),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_probability_never_produces_an_error() {
+        for &sample in &[0.0, 0.3, 0.5, 0.9999] {
+            assert_eq!(sample_depolarizing_error(0.0, sample), None);
+        }
+    }
+
+    #[test]
+    fn certain_probability_always_produces_an_error() {
+        for &sample in &[0.0, 0.32, 0.65, 0.9999] {
+            assert!(sample_depolarizing_error(1.0, sample).is_some());
+        }
+    }
+
+    #[test]
+    fn the_three_pauli_ranges_are_evenly_split_and_in_order() {
+        let p = 0.9;
+        // Just inside each third of [0, p).
+        assert_eq!(sample_depolarizing_error(p, 0.0), Some(PauliError::X));
+        assert_eq!(sample_depolarizing_error(p, p / 3.0 - 1e-9), Some(PauliError::X));
+        assert_eq!(sample_depolarizing_error(p, p / 3.0), Some(PauliError::Y));
+        assert_eq!(sample_depolarizing_error(p, 2.0 * p / 3.0 - 1e-9), Some(PauliError::Y));
+        assert_eq!(sample_depolarizing_error(p, 2.0 * p / 3.0), Some(PauliError::Z));
+        assert_eq!(sample_depolarizing_error(p, p - 1e-9), Some(PauliError::Z));
+        // Just past p: no error.
+        assert_eq!(sample_depolarizing_error(p, p), None);
+        assert_eq!(sample_depolarizing_error(p, 0.9999), None);
+    }
+}

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -101,16 +101,16 @@ fn drop_zero_pass(gates: &[NativeGate]) -> Vec<NativeGate> {
             // effect the caller depends on.
             NativeGate::Measure(..) => true,
             // Drop iff the *wrapped* gate would be dropped on its own --
-            // an If(clbit, value, Rz(q, ~0)) is a no-op regardless of
-            // clbit's value, exactly as much as a bare Rz(q, ~0) would
-            // be, so this recurses into the same rule rather than
+            // an If(conditions, Rz(q, ~0)) is a no-op regardless of the
+            // conditions' values, exactly as much as a bare Rz(q, ~0)
+            // would be, so this recurses into the same rule rather than
             // keeping every If unconditionally (which would leave
             // genuinely-zero conditioned rotations behind forever).
             // Measure/If can't actually appear as `inner` here (see
             // NativeGate::If's doc comment), but are matched
             // conservatively (never dropped) rather than left
             // unreachable, so this stays a total function.
-            NativeGate::If(_, _, inner) => match inner.as_ref() {
+            NativeGate::If(_, inner) => match inner.as_ref() {
                 NativeGate::Rz(_, a) | NativeGate::Ry(_, a) => a.abs() > EPS,
                 NativeGate::Rzz(_, _, a) => a.abs() > EPS,
                 NativeGate::Measure(..) | NativeGate::If(..) => true,
@@ -163,9 +163,9 @@ mod tests {
     #[test]
     fn keeps_a_conditioned_nonzero_rotation() {
         let mut nc = NativeCircuit::new(1);
-        nc.push(NativeGate::If(0, true, Box::new(NativeGate::Rz(0, 0.5))));
+        nc.push(NativeGate::If(vec![(0, true)], Box::new(NativeGate::Rz(0, 0.5))));
         let opt = optimize(&nc);
-        assert_eq!(opt.gates, vec![NativeGate::If(0, true, Box::new(NativeGate::Rz(0, 0.5)))]);
+        assert_eq!(opt.gates, vec![NativeGate::If(vec![(0, true)], Box::new(NativeGate::Rz(0, 0.5)))]);
     }
 
     #[test]
@@ -173,7 +173,7 @@ mod tests {
         // If(clbit, value, Rz(q, ~0)) is a no-op no matter what clbit
         // holds -- same as an unconditioned zero-angle Rz.
         let mut nc = NativeCircuit::new(1);
-        nc.push(NativeGate::If(0, true, Box::new(NativeGate::Rz(0, 0.0))));
+        nc.push(NativeGate::If(vec![(0, true)], Box::new(NativeGate::Rz(0, 0.0))));
         let opt = optimize(&nc);
         assert!(opt.gates.is_empty());
     }
@@ -187,8 +187,8 @@ mod tests {
         // currently check -- see this module's doc comment for the
         // scope this pass covers.)
         let mut nc = NativeCircuit::new(1);
-        nc.push(NativeGate::If(0, true, Box::new(NativeGate::Rz(0, 0.2))));
-        nc.push(NativeGate::If(0, true, Box::new(NativeGate::Rz(0, 0.3))));
+        nc.push(NativeGate::If(vec![(0, true)], Box::new(NativeGate::Rz(0, 0.2))));
+        nc.push(NativeGate::If(vec![(0, true)], Box::new(NativeGate::Rz(0, 0.3))));
         let opt = optimize(&nc);
         assert_eq!(opt.gates.len(), 2, "conditioned rotations should not be fused by this pass");
     }

--- a/src/pulse.rs
+++ b/src/pulse.rs
@@ -423,10 +423,42 @@ fn schedule_one(
     busy_until: &mut HashMap<usize, f64>,
     instructions: &mut Vec<PulseInstruction>,
 ) -> Result<(), String> {
-    fn qubit_time(q: usize, busy_until: &HashMap<usize, f64>) -> f64 {
-        *busy_until.get(&q).unwrap_or(&0.0)
+    match *g {
+        BackendGate::If(_, ref inner) => {
+            // Scheduled exactly as `inner` would be on its own --
+            // *this* static `Schedule` only ever describes which
+            // pulses exist and when, never whether one actually fires
+            // at runtime. See [`crate::sequencer`] for the layer that
+            // actually represents the branch -- this function
+            // deliberately stays a flat, unconditional pulse list; it
+            // is not where real-time control-flow belongs.
+            schedule_one(inner, cal, busy_until, instructions)
+        }
+        _ => push_leaf_pulse(g, cal, busy_until, instructions),
     }
+}
 
+fn qubit_time(q: usize, busy_until: &HashMap<usize, f64>) -> f64 {
+    *busy_until.get(&q).unwrap_or(&0.0)
+}
+
+/// Appends the pulse(s) for one *leaf* `BackendGate` -- everything
+/// except `If`, which has no pulse of its own (only its `inner` does).
+/// This is the actual physical-pulse-construction logic; both
+/// [`schedule_one`] (the static, unconditional `Schedule` this module
+/// builds) and [`crate::sequencer::compile`] (the real branching
+/// program one layer below it) call this for the same leaf gate, so
+/// the two never have two different opinions about what pulse a given
+/// gate produces -- only about whether/when it's allowed to fire.
+///
+/// `pub(crate)` rather than private specifically so `sequencer.rs` can
+/// reuse it; every other function in this module stays private.
+pub(crate) fn push_leaf_pulse(
+    g: &BackendGate,
+    cal: &PulseCalibration,
+    busy_until: &mut HashMap<usize, f64>,
+    instructions: &mut Vec<PulseInstruction>,
+) -> Result<(), String> {
     match *g {
         BackendGate::Rz(q, theta) => {
             let t = qubit_time(q, busy_until);
@@ -507,24 +539,10 @@ fn schedule_one(
             });
             busy_until.insert(q, t + duration);
         }
-        BackendGate::If(_, _, ref inner) => {
-            // Scheduled exactly as `inner` would be on its own --
-            // *this* static `Schedule` only ever describes which
-            // pulses exist and when, never whether one actually fires
-            // at runtime (see `emit.rs`'s execution of this variant,
-            // which is what makes that call). That split mirrors how
-            // this crate already treats the analogous case one layer
-            // up: `backend::lower`'s `If` handling compiles the pulse
-            // unconditionally into the schedule; the real-time
-            // classical feed-forward decision belongs to control
-            // electronics this static model doesn't represent, not to
-            // schedule construction. A genuine dynamic-circuits
-            // scheduler -- one that can express "wait for the
-            // classical result, then branch, with real feed-forward
-            // latency" -- is real, separate follow-on work this
-            // function doesn't attempt.
-            schedule_one(inner, cal, busy_until, instructions)?;
-        }
+        BackendGate::If(..) => unreachable!(
+            "push_leaf_pulse called on If -- If has no pulse of its own, only its inner \
+             does; callers must unwrap it first (schedule_one does; sequencer::compile does)"
+        ),
     }
     Ok(())
 }
@@ -855,7 +873,7 @@ mod tests {
         // private outside backend.rs -- push is pub(crate), so the
         // gates themselves can still be added directly.
         let mut conditioned = backend::lower(&Circuit::new(1), Backend::TrappedIon);
-        conditioned.push(BackendGate::If(0, true, Box::new(BackendGate::Rot(0, PI))));
+        conditioned.push(BackendGate::If(vec![(0, true)], Box::new(BackendGate::Rot(0, PI))));
         let mut plain = backend::lower(&Circuit::new(1), Backend::TrappedIon);
         plain.push(BackendGate::Rot(0, PI));
 
@@ -871,7 +889,7 @@ mod tests {
         // early -- same overlap-freedom guarantee as an unconditioned
         // two-qubit gate.
         let mut bc = backend::lower(&Circuit::new(2), Backend::TrappedIon);
-        bc.push(BackendGate::If(0, true, Box::new(BackendGate::Rzz(0, 1, PI / 2.0))));
+        bc.push(BackendGate::If(vec![(0, true)], Box::new(BackendGate::Rzz(0, 1, PI / 2.0))));
         bc.push(BackendGate::Rot(0, PI));
         let sched = schedule(&bc, &trapped_ion_pulse_calibration()).unwrap();
         assert!(

--- a/src/qasm.rs
+++ b/src/qasm.rs
@@ -122,7 +122,7 @@ pub fn parse(source: &str) -> Result<Circuit, String> {
             continue;
         }
         // This crate's own classical-control extension:
-        // `if (c[N]==0|1) <gate-stmt>;` -- see this module's doc
+        // `if (c[N]==0|1 && ...) <gate-stmt>;` -- see this module's doc
         // comment and `parse_if_condition`'s own doc comment for what
         // this is (and isn't) standard for.
         if let Some(rest) = stmt.strip_prefix("if") {
@@ -132,12 +132,15 @@ pub fn parse(source: &str) -> Result<Circuit, String> {
             let c_count = num_clbits.ok_or_else(|| {
                 format!("line {}: `if` before a classical register declaration: `{}`", lineno, stmt)
             })?;
-            let (clbit, value, inner_stmt) = parse_if_condition(rest, lineno)?;
-            if clbit >= c_count {
-                return Err(format!(
-                    "line {}: classical bit index {} out of range for a {}-bit register: `{}`",
-                    lineno, clbit, c_count, stmt
-                ));
+            let (conditions, inner_stmt) = parse_if_condition(rest, lineno)?;
+            for &(clbit, _) in &conditions {
+                if clbit >= c_count {
+                    return Err(format!(
+                        "line {}: classical bit index {} out of range for a {}-bit register: \
+                         `{}`",
+                        lineno, clbit, c_count, stmt
+                    ));
+                }
             }
             let inner_trimmed = inner_stmt.trim();
             if inner_trimmed.starts_with("measure") {
@@ -163,7 +166,7 @@ pub fn parse(source: &str) -> Result<Circuit, String> {
                     ));
                 }
             }
-            circuit.gates.push(Gate::If(clbit, value, Box::new(inner_gate)));
+            circuit.gates.push(Gate::If(conditions, Box::new(inner_gate)));
             continue;
         }
         // QASM 3.0's assignment-style measure: `c[0] = measure q[0];`
@@ -479,15 +482,18 @@ fn parse_measure_statement(rest: &str, lineno: usize) -> Result<(usize, usize), 
 }
 
 /// Parses this crate's own classical-control extension --
-/// `if (c[N]==0|1) <gate-stmt>` -- after the leading `if` keyword has
-/// already been stripped. Not standard OPENQASM (see this module's doc
-/// comment) -- `emit.rs::to_qasm`/`to_qasm3`'s own dialect for a
-/// single classically-conditioned gate. Returns `(clbit, value,
+/// `if (c[N]==0|1 && c[M]==0|1 && ...) <gate-stmt>` -- after the
+/// leading `if` keyword has already been stripped. Not standard
+/// OPENQASM (see this module's doc comment) -- `emit.rs::to_qasm`/
+/// `to_qasm3`'s own dialect for a single classically-conditioned gate,
+/// generalized to a `&&`-joined list of bit-equality clauses so it can
+/// express a real multi-bit joint condition (`ir::Gate::If`'s AND
+/// semantics), not just a single one. Returns `(conditions,
 /// remaining_statement_text)`; the caller is responsible for rejecting
 /// a `measure`/`if` as the remaining statement (see `Circuit::validate`'s
 /// matching rule) and then parsing whatever's left with the ordinary
 /// [`parse_gate_statement`].
-fn parse_if_condition(rest: &str, lineno: usize) -> Result<(usize, bool, &str), String> {
+fn parse_if_condition(rest: &str, lineno: usize) -> Result<(Vec<(usize, bool)>, &str), String> {
     let rest = rest.trim_start();
     let open = rest
         .strip_prefix('(')
@@ -496,25 +502,34 @@ fn parse_if_condition(rest: &str, lineno: usize) -> Result<(usize, bool, &str), 
         .find(')')
         .ok_or_else(|| format!("line {}: `if` missing closing `)`: `if{}`", lineno, rest))?;
     let condition = &open[..close];
-    let eq = condition.find("==").ok_or_else(|| {
-        format!(
-            "line {}: `if` condition must be `c[N]==0` or `c[N]==1`: `if({})`",
-            lineno, condition
-        )
-    })?;
-    let clbit = parse_index_ref(&condition[..eq], lineno)?;
-    let rhs = condition[eq + 2..].trim();
-    let value = match rhs {
-        "0" => false,
-        "1" => true,
-        other => {
-            return Err(format!(
-                "line {}: `if` condition value must be `0` or `1`, got `{}`: `if({})`",
-                lineno, other, condition
-            ))
-        }
-    };
-    Ok((clbit, value, &open[close + 1..]))
+    let mut conditions = Vec::new();
+    for clause in condition.split("&&") {
+        let clause = clause.trim();
+        let eq = clause.find("==").ok_or_else(|| {
+            format!(
+                "line {}: `if` condition must be one or more `c[N]==0`/`c[N]==1` clauses \
+                 joined by `&&`: `if({})`",
+                lineno, condition
+            )
+        })?;
+        let clbit = parse_index_ref(&clause[..eq], lineno)?;
+        let rhs = clause[eq + 2..].trim();
+        let value = match rhs {
+            "0" => false,
+            "1" => true,
+            other => {
+                return Err(format!(
+                    "line {}: `if` condition value must be `0` or `1`, got `{}`: `if({})`",
+                    lineno, other, condition
+                ))
+            }
+        };
+        conditions.push((clbit, value));
+    }
+    if conditions.is_empty() {
+        return Err(format!("line {}: `if` condition is empty: `if({})`", lineno, condition));
+    }
+    Ok((conditions, &open[close + 1..]))
 }
 
 #[cfg(test)]
@@ -641,7 +656,7 @@ mod if_tests {
         let circuit = parse(src).unwrap();
         assert_eq!(
             circuit.gates,
-            vec![Gate::Measure(0, 0), Gate::If(0, true, Box::new(Gate::X(1)))]
+            vec![Gate::Measure(0, 0), Gate::If(vec![(0, true)], Box::new(Gate::X(1)))]
         );
     }
 
@@ -649,14 +664,14 @@ mod if_tests {
     fn parses_a_conditioned_gate_with_a_parameter() {
         let src = "OPENQASM 2.0;\nqreg q[2];\ncreg c[1];\nif (c[0]==0) rz(0.5) q[1];\n";
         let circuit = parse(src).unwrap();
-        assert_eq!(circuit.gates, vec![Gate::If(0, false, Box::new(Gate::Rz(1, 0.5)))]);
+        assert_eq!(circuit.gates, vec![Gate::If(vec![(0, false)], Box::new(Gate::Rz(1, 0.5)))]);
     }
 
     #[test]
     fn parses_a_conditioned_two_qubit_gate() {
         let src = "OPENQASM 2.0;\nqreg q[3];\ncreg c[1];\nif (c[0]==1) cx q[1], q[2];\n";
         let circuit = parse(src).unwrap();
-        assert_eq!(circuit.gates, vec![Gate::If(0, true, Box::new(Gate::Cx(1, 2)))]);
+        assert_eq!(circuit.gates, vec![Gate::If(vec![(0, true)], Box::new(Gate::Cx(1, 2)))]);
     }
 
     #[test]
@@ -699,6 +714,6 @@ mod if_tests {
     fn if_works_identically_under_qasm3_declarations() {
         let src = "OPENQASM 3.0;\nqubit[2] q;\nbit[1] c;\nif (c[0]==1) x q[1];\n";
         let circuit = parse(src).unwrap();
-        assert_eq!(circuit.gates, vec![Gate::If(0, true, Box::new(Gate::X(1)))]);
+        assert_eq!(circuit.gates, vec![Gate::If(vec![(0, true)], Box::new(Gate::X(1)))]);
     }
 }

--- a/src/readout.rs
+++ b/src/readout.rs
@@ -1,0 +1,253 @@
+//! Classical readout (measurement-assignment) error, modeled
+//! independently of every other noise source this crate has.
+//!
+//! # Why this is separate from everything else
+//! `fidelity.rs`'s calibrations price gate error. `pulse.rs`'s
+//! `PulseCalibration` describes the physical pulse shapes gates and
+//! readout compile to. Neither says anything about what happens
+//! *after* a qubit is projectively measured: the classical signal
+//! chain (amplifier, digitizer, discriminator/decoder) that turns a
+//! real analog readout trace into a reported "0" or "1" is itself
+//! imperfect, and on real NISQ hardware this is often the *single
+//! largest* error source in the whole system -- bigger than any
+//! individual gate error (see e.g. Google's own Willow spec sheet,
+//! where mean simultaneous repetitive measurement error is larger
+//! than either its single- or two-qubit gate error; see this module's
+//! own calibrations below for the cited figure).
+//!
+//! This module models that specific failure mode: a *classical*
+//! confusion between the true, exactly-collapsed measurement outcome
+//! and what gets reported. It deliberately does not attempt to model
+//! *why* the misassignment happens (T1 decay during the integration
+//! window vs. a purely electronic discriminator error near the
+//! threshold are physically different mechanisms with the same
+//! observable signature) -- real vendor calibration data is reported
+//! as a single confusion matrix without distinguishing mechanism, and
+//! this module matches that level of description rather than
+//! inventing a finer-grained physical model no cited source supports.
+//!
+//! # Where this plugs in
+//! [`crate::sequencer::execute_with_readout_noise`] is the actual
+//! integration point: it corrupts the classical bit a
+//! `SeqInstr::MeasureInto` writes (the value `Gate::If`/
+//! `SeqInstr::JumpIfEqual` branch on and the value a caller ultimately
+//! reads back), while leaving the *quantum* collapse
+//! `QuantumRegister::measure_single_qubit` performs completely exact.
+//! That split is deliberate and physically meaningful, not a
+//! simplification of convenience: it's the standard way readout error
+//! is modeled in the field (e.g. Qiskit's own `ReadoutError` noise
+//! channel works the same way -- a purely classical confusion matrix
+//! applied on top of an otherwise-ideal simulator).
+//!
+//! # Why this crate's library code takes randomness as a parameter
+//! This crate's `[dependencies]` (Cargo.toml) deliberately has no RNG
+//! crate -- only `[dev-dependencies]` does, for examples and tests.
+//! [`corrupt_readout`] is therefore a pure function of an already-drawn
+//! `f64 in [0, 1)`, not something that draws its own randomness; the
+//! caller supplies the sample however it likes (a `rand`-crate RNG in
+//! an example, `sirraya_qutub`'s own randomness elsewhere, a fixed
+//! sequence in a test). This mirrors how the rest of this crate keeps
+//! genuine randomness confined to `sirraya_qutub`'s own measurement
+//! collapse rather than adding a second, independent source of it.
+
+use crate::backend::Backend;
+
+/// Confusion probabilities for a single-qubit computational-basis
+/// measurement: `p01` is P(report "1" | true state "0"), `p10` is
+/// P(report "0" | true state "1"). Real hardware is usually
+/// asymmetric -- a qubit truly in `|1>` has a real decay channel
+/// (T1) that can flip it to `|0>` during the readout integration
+/// window; the reverse process has no comparable mechanism -- so
+/// `p10 > p01` is the physically expected direction whenever a cited
+/// source actually reports the asymmetric split (see
+/// [`ReadoutCalibration::rigetti_ankaa3`] for a real, published
+/// example of exactly this asymmetry). Where a cited source only
+/// publishes one combined average, both fields are set equal to it --
+/// an explicit, stated simplification per calibration, never a claim
+/// that the real hardware is actually symmetric.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ReadoutCalibration {
+    pub name: &'static str,
+    pub backend: Backend,
+    pub p01: f64,
+    pub p10: f64,
+}
+
+impl ReadoutCalibration {
+    /// The average assignment error, `(p01 + p10) / 2` -- the single
+    /// number vendors most often publish in place of the full
+    /// confusion matrix (see e.g. Rigetti's own published definition:
+    /// "the reported readout fidelity is computed by taking the trace
+    /// of the individual confusion matrix and dividing by two," i.e.
+    /// exactly this quantity subtracted from 1).
+    pub fn average_error(&self) -> f64 {
+        (self.p01 + self.p10) / 2.0
+    }
+
+    /// Quantinuum Helios (98-qubit trapped-ion). SPAM (state
+    /// preparation *and* measurement combined -- Quantinuum's own
+    /// published benchmarking methodology reports one number for
+    /// both together, not pure measurement-assignment error in
+    /// isolation, so this is a mild overestimate of readout error
+    /// alone) fidelity ~99.95%, i.e. error rate ~4.8e-4, from
+    /// Quantinuum/Sandia's Nature-validated benchmarking of Helios
+    /// (launched Nov 2025) -- the same device this crate's
+    /// `fidelity::PublishedCalibration::quantinuum_helios_2026`
+    /// already cites for gate fidelity. No asymmetric p01/p10 split
+    /// has been published for this figure.
+    pub fn quantinuum_helios_2026() -> Self {
+        Self {
+            name: "Quantinuum Helios (98-qubit trapped-ion; SPAM fidelity ~99.95%, error \
+                   ~4.8e-4, from Quantinuum/Sandia Nature-validated benchmarking, Nov 2025 \
+                   launch -- combined state-prep+measurement, not pure readout in isolation, \
+                   and no published asymmetric p01/p10 split)",
+            backend: Backend::TrappedIon,
+            p01: 4.8e-4,
+            p10: 4.8e-4,
+        }
+    }
+
+    /// IBM Heron r2 (156-qubit superconducting), specifically
+    /// `ibm_marrakesh`. Device-wide average readout-error rate 3%,
+    /// from a Nov-Dec 2024 calibration snapshot (arXiv:2510.13577,
+    /// Table S3) -- a different, earlier snapshot than this crate's
+    /// own `fidelity::PublishedCalibration::ibm_heron_r2`'s single-/
+    /// two-qubit *gate* error citation (Dec 2025), used here because
+    /// that source doesn't itself report readout error. No asymmetric
+    /// p01/p10 split published for this figure (a device- and
+    /// direction-averaged number).
+    pub fn ibm_heron_r2() -> Self {
+        Self {
+            name: "IBM Heron r2 (156-qubit superconducting, ibm_marrakesh; device-wide \
+                   average readout-error rate 3%, Nov-Dec 2024 snapshot, per arXiv:2510.13577 \
+                   Table S3 -- no published asymmetric p01/p10 split)",
+            backend: Backend::IbmQ,
+            p01: 0.03,
+            p10: 0.03,
+        }
+    }
+
+    /// Rigetti Ankaa-3 (84-qubit superconducting). A genuine,
+    /// published *asymmetric* confusion matrix -- not a combined
+    /// average this module had to symmetrize itself:
+    /// P(report 1 | true 0) = 2.40%, P(report 0 | true 1) = 7.26%.
+    /// The ~3x asymmetry is exactly the physically expected direction
+    /// (see this struct's own doc comment on T1 decay during
+    /// readout), and having a real cited source for it rather than
+    /// assuming it is why this is the one calibration in this module
+    /// with `p01 != p10`. Per arXiv:2604.19832, Eq. (10).
+    pub fn rigetti_ankaa3() -> Self {
+        Self {
+            name: "Rigetti Ankaa-3 (84-qubit superconducting); published confusion matrix \
+                   P(1|0)=2.40%, P(0|1)=7.26%, per arXiv:2604.19832 Eq. (10)",
+            backend: Backend::Rigetti,
+            p01: 0.0240,
+            p10: 0.0726,
+        }
+    }
+
+    /// Google Willow Chip 1 (105-qubit superconducting, CZ-tuned
+    /// configuration, Dec 2024). Mean simultaneous repetitive
+    /// measurement error 0.77%, from the same official Willow spec
+    /// sheet this crate's own
+    /// `fidelity::PublishedCalibration::google_willow_2024` already
+    /// cites for its gate-fidelity figures (see that constructor's own
+    /// doc comment for the full citation and why Chip 1 specifically)
+    /// -- kept to the same primary source deliberately, rather than
+    /// pulling a readout figure from a different characterization. No
+    /// asymmetric p01/p10 split published for this figure.
+    pub fn google_willow_2024() -> Self {
+        Self {
+            name: "Google Willow Chip 1 (105-qubit superconducting, CZ-tuned; mean \
+                   simultaneous repetitive measurement error 0.77%, per Google's own Willow \
+                   spec sheet, published Dec 9 2024 -- no published asymmetric p01/p10 split)",
+            backend: Backend::Google,
+            p01: 0.0077,
+            p10: 0.0077,
+        }
+    }
+}
+
+/// Applies `cal`'s confusion probabilities to a `true_bit` (the real,
+/// exact outcome of a projective measurement -- e.g. from
+/// `QuantumRegister::measure_single_qubit`), returning the classical
+/// bit a real, imperfect readout chain would actually report. Pure
+/// and deterministic given `uniform_sample` (drawn from U[0, 1) by
+/// the caller) -- see this module's doc comment on why library code
+/// here never draws its own randomness.
+pub fn corrupt_readout(true_bit: u8, cal: &ReadoutCalibration, uniform_sample: f64) -> u8 {
+    let flip_probability = if true_bit == 0 { cal.p01 } else { cal.p10 };
+    if uniform_sample < flip_probability {
+        1 - true_bit
+    } else {
+        true_bit
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_published_calibration_has_valid_probabilities() {
+        for cal in [
+            ReadoutCalibration::quantinuum_helios_2026(),
+            ReadoutCalibration::ibm_heron_r2(),
+            ReadoutCalibration::rigetti_ankaa3(),
+            ReadoutCalibration::google_willow_2024(),
+        ] {
+            assert!((0.0..=1.0).contains(&cal.p01), "{}: p01 out of range", cal.name);
+            assert!((0.0..=1.0).contains(&cal.p10), "{}: p10 out of range", cal.name);
+        }
+    }
+
+    #[test]
+    fn rigetti_calibration_is_genuinely_asymmetric() {
+        // The one calibration here with a real published p01 != p10 --
+        // confirms this module isn't quietly symmetrizing everything.
+        let cal = ReadoutCalibration::rigetti_ankaa3();
+        assert!(cal.p10 > cal.p01, "expected the physically-typical p10 > p01 asymmetry");
+    }
+
+    #[test]
+    fn corrupt_readout_respects_the_strict_less_than_threshold() {
+        let cal = ReadoutCalibration {
+            name: "test",
+            backend: Backend::TrappedIon,
+            p01: 0.1,
+            p10: 0.2,
+        };
+        // true=0: flips iff sample < 0.1
+        assert_eq!(corrupt_readout(0, &cal, 0.05), 1);
+        assert_eq!(corrupt_readout(0, &cal, 0.1), 0); // exactly at threshold: not flipped
+        assert_eq!(corrupt_readout(0, &cal, 0.5), 0);
+        // true=1: flips iff sample < 0.2
+        assert_eq!(corrupt_readout(1, &cal, 0.1), 0);
+        assert_eq!(corrupt_readout(1, &cal, 0.2), 1);
+        assert_eq!(corrupt_readout(1, &cal, 0.5), 1);
+    }
+
+    #[test]
+    fn zero_error_calibration_never_flips() {
+        let cal = ReadoutCalibration { name: "test", backend: Backend::TrappedIon, p01: 0.0, p10: 0.0 };
+        for &sample in &[0.0, 0.3, 0.9999] {
+            assert_eq!(corrupt_readout(0, &cal, sample), 0);
+            assert_eq!(corrupt_readout(1, &cal, sample), 1);
+        }
+    }
+
+    #[test]
+    fn certain_error_calibration_always_flips() {
+        let cal = ReadoutCalibration { name: "test", backend: Backend::TrappedIon, p01: 1.0, p10: 1.0 };
+        for &sample in &[0.0, 0.3, 0.9999] {
+            assert_eq!(corrupt_readout(0, &cal, sample), 1);
+            assert_eq!(corrupt_readout(1, &cal, sample), 0);
+        }
+    }
+
+    #[test]
+    fn average_error_matches_the_rigetti_style_definition() {
+        let cal = ReadoutCalibration::rigetti_ankaa3();
+        assert!((cal.average_error() - (0.0240 + 0.0726) / 2.0).abs() < 1e-12);
+    }
+}

--- a/src/resource_estimate.rs
+++ b/src/resource_estimate.rs
@@ -1,0 +1,484 @@
+//! Fault-tolerant resource estimation: T-count and T-depth, the
+//! currency fault-tolerant (surface-code-era) quantum computing is
+//! actually budgeted in -- as distinct from [`crate::fidelity`]'s
+//! NISQ-era depolarizing-error budget, which this module deliberately
+//! does not replace or subsume.
+//!
+//! # Why T-count, not gate count
+//! Under most quantum error correction codes (surface codes included),
+//! Clifford gates (`H`, `S`, `Sdg`, `X`, `Y`, `Z`, `Cx`, `Cz`, `Swap`)
+//! are comparatively cheap -- they can be implemented transversally or
+//! by Pauli-frame bookkeeping, without consuming a distilled resource
+//! state. A `T` gate cannot: it needs a magic state, and magic-state
+//! distillation is, in most current architectures, the dominant cost
+//! of the entire computation -- often cited as consuming the large
+//! majority of a fault-tolerant algorithm's physical qubits and time.
+//! So the question "how many T gates does this circuit need" is a far
+//! more decision-relevant number, this early in a circuit's life, than
+//! "how many gates does this circuit have."
+//!
+//! # What this module does and does not estimate
+//! This estimates **logical** T-count/T-depth: how many T gates (or
+//! T-equivalent rotation-synthesis budget) the circuit needs, and how
+//! many of those can run in parallel. It deliberately does **not**
+//! estimate physical qubit count, code distance, or wall-clock time --
+//! those depend on a specific error-correcting code, its distance, the
+//! target logical error rate, and the physical error rate of a
+//! specific device, none of which this module has an opinion on. That
+//! is real, separate, and necessarily hardware-specific follow-on
+//! work; conflating it with this module's purely algorithmic count
+//! would make this module's numbers only as trustworthy as a set of
+//! assumptions about hardware that doesn't exist yet.
+//!
+//! # How a continuous rotation gets a T-count
+//! This crate's native gate set is `{Rz, Ry, Rzz}` -- continuous-angle
+//! rotations, not the discrete Clifford+T set fault-tolerant algorithms
+//! are actually compiled to. An arbitrary single-qubit rotation has no
+//! *exact* finite Clifford+T decomposition in general; it can only be
+//! *approximated* to within a target precision `epsilon`, at a T-gate
+//! cost that grows as that precision tightens. This module uses the
+//! well-known asymptotic result for optimal ancilla-free Clifford+T
+//! synthesis of a single-qubit z-rotation (Ross & Selinger, "Optimal
+//! ancilla-free Clifford+T approximation of z-rotations", 2016):
+//! roughly `3 * log2(1/epsilon)` T gates for an epsilon-accurate
+//! approximation. This is the *asymptotically optimal* count a real
+//! synthesis algorithm (e.g. their own `gridsynth`) can achieve; it is
+//! not what a naive Solovay-Kitaev synthesis would cost (which is
+//! asymptotically worse), and it is an estimate, not an actual
+//! synthesis -- this module never emits real Clifford+T gates, only a
+//! number. Getting an exact count for a specific circuit means running
+//! a real synthesis tool against the real target angles.
+//!
+//! A rotation whose angle is an exact multiple of `pi/2` is already
+//! Clifford (0 T gates); an exact odd multiple of `pi/4` is exactly
+//! one `T`/`Tdg` up to a free Clifford correction. Both are detected
+//! and costed exactly, not run through the asymptotic estimate --
+//! `Rz(pi/2)` (i.e. `S`) should cost 0 T gates, not `3*log2(1/epsilon)`
+//! of them, and this module gets that right rather than pessimistic.
+//!
+//! # Two-qubit and multi-rotation gates
+//! `Rzz(a, b, theta)` is `Cx(a,b) . Rz(b, theta) . Cx(a,b)` (see
+//! `native.rs`'s own decomposition) -- the two `Cx`s are Clifford, so
+//! `Rzz`'s T-cost is exactly one single-qubit rotation's T-cost at the
+//! same angle. `Rxx`/`Ryy` reduce to `Rzz` by Clifford conjugation
+//! (also in `native.rs`), so the same reasoning applies transitively.
+//! Rather than re-deriving any of this, this module runs the circuit
+//! through the crate's own [`crate::native::decompose`] +
+//! [`crate::optimize::optimize`] first, then costs only the resulting
+//! `Rz`/`Ry`/`Rzz` -- so the T-count is grounded in the exact same
+//! identities the rest of the crate already tests against the real
+//! simulator, not a second, independently-derived model of what those
+//! gates cost.
+//!
+//! # Classical control
+//! A [`crate::ir::Gate::If`]-conditioned gate costs exactly what its
+//! `inner` would unconditioned -- the classical condition itself is
+//! assumed free (a fast enough decoder to keep up with the code cycle;
+//! see this crate's own architecture notes on why that assumption is a
+//! real, separate hardware constraint this module doesn't model). A
+//! `Measure` costs 0 T gates but is tracked as its own count, since
+//! measurement is a real resource (and, on some codes, the *dominant*
+//! one for syndrome extraction) that a T-count alone would hide.
+
+use crate::ir::{Circuit, Gate};
+use crate::native::{decompose, NativeGate};
+use crate::optimize::optimize;
+use std::f64::consts::{PI, TAU};
+
+/// Default precision target for an approximated (non-exact) rotation,
+/// if the caller doesn't have a more specific one in mind. `1e-10` is
+/// a common rule-of-thumb starting point for a single rotation inside
+/// a larger algorithm (tighter than the end-to-end algorithmic
+/// accuracy target, since errors from many rotations can accumulate) --
+/// not a universal constant, and callers with a real accuracy budget
+/// should pass their own via [`estimate_circuit_resources_with_epsilon`].
+pub const DEFAULT_ROTATION_EPSILON: f64 = 1e-10;
+
+/// How one rotation's T-cost was determined -- kept alongside the
+/// count itself so a caller can tell an exact 0 (a Clifford angle)
+/// apart from an estimate that happens to be small, or flag how many
+/// rotations in a circuit are exact vs. approximated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RotationSynthesis {
+    /// Angle is an exact multiple of `2*pi` -- the identity; 0 gates
+    /// of any kind, not even a Clifford one.
+    Identity,
+    /// Angle is an exact multiple of `pi/2` -- already Clifford
+    /// (`Z`/`S`/`Sdg`, or the identity's own multiples); 0 T gates.
+    Clifford,
+    /// Angle is an exact odd multiple of `pi/4` -- exactly one
+    /// `T`/`Tdg` up to a free Clifford correction.
+    ExactT,
+    /// No exact finite Clifford+T decomposition; costed via the
+    /// Ross-Selinger asymptotic estimate at the epsilon this
+    /// estimate was run with -- see this module's doc comment.
+    Approximate,
+}
+
+/// One rotation's contribution to a circuit's resource budget.
+#[derive(Debug, Clone, Copy)]
+pub struct RotationCost {
+    pub synthesis: RotationSynthesis,
+    pub t_count: usize,
+}
+
+/// The full resource budget for a circuit: T-count/T-depth (the two
+/// numbers that matter for a fault-tolerant cost estimate -- see this
+/// module's doc comment), plus enough supporting detail to sanity-check
+/// where they came from.
+#[derive(Debug, Clone, Default)]
+pub struct ResourceBudget {
+    /// Total T gates (exact `T`/`Tdg` gates in the source, plus every
+    /// rotation's synthesis cost at whatever `epsilon` this estimate
+    /// was run with).
+    pub t_count: usize,
+    /// Longest chain of T-consuming operations on any single qubit --
+    /// a lower bound on how many sequential magic-state consumption
+    /// rounds the circuit needs, the same "critical path" sense
+    /// `depth` is used in elsewhere in this crate's examples, just
+    /// counting only T-contributing layers rather than every gate.
+    ///
+    /// **This is a conservative upper bound, not an optimized T-depth.**
+    /// It counts a new layer every time a T-consuming gate follows
+    /// another one on the same wire in program order. A real T-depth
+    /// optimization pass can often do better, because Clifford gates
+    /// between two T gates on the same wire don't have to physically
+    /// block them the way this simple model assumes -- they can often
+    /// be tracked in software (Pauli-frame bookkeeping) and commuted
+    /// out of the way instead. Getting the *optimized* number needs a
+    /// real T-depth-reduction pass (a separate, real piece of
+    /// follow-on work), not just this circuit-order count.
+    pub t_depth: usize,
+    /// Every Clifford gate the circuit needs (`H`/`S`/`Sdg`/`X`/`Y`/
+    /// `Z`/`Cx`/`Cz`/`Swap`, plus the free Clifford part of every
+    /// `RotationSynthesis::Clifford`/`ExactT` rotation) -- reported
+    /// because "how many Cliffords" is a real, separate cost on
+    /// several real error-correction schemes (lattice surgery merges,
+    /// for instance), even though it's not the dominant one T-count is.
+    pub clifford_count: usize,
+    /// Real measurements in the circuit -- tracked separately from
+    /// T-count for the reason given in this module's doc comment
+    /// (measurement is a real, sometimes-dominant resource of its own,
+    /// not something a T-count captures).
+    pub measurement_count: usize,
+    /// How many rotations were costed exactly (`Identity`/`Clifford`/
+    /// `ExactT`) vs. via the asymptotic estimate (`Approximate`) --
+    /// lets a caller see how much of `t_count` is exact bookkeeping
+    /// vs. an estimate that would change under a different `epsilon`.
+    pub exact_rotations: usize,
+    pub approximated_rotations: usize,
+}
+
+/// Estimates `circuit`'s fault-tolerant resource budget at
+/// [`DEFAULT_ROTATION_EPSILON`] -- see
+/// [`estimate_circuit_resources_with_epsilon`] to choose a different
+/// precision target.
+pub fn estimate_circuit_resources(circuit: &Circuit) -> ResourceBudget {
+    estimate_circuit_resources_with_epsilon(circuit, DEFAULT_ROTATION_EPSILON)
+}
+
+/// As [`estimate_circuit_resources`], but at caller-chosen rotation
+/// precision `epsilon`. Runs `circuit` through this crate's own
+/// [`decompose`] + [`optimize`] first (see this module's doc comment
+/// on why), so the reported T-count reflects the circuit *after* the
+/// same peephole cleanup `native.rs`'s pipeline already applies before
+/// execution -- not the raw, unoptimized source gate count, which
+/// would overstate the cost of a circuit with cancelling rotations.
+pub fn estimate_circuit_resources_with_epsilon(circuit: &Circuit, epsilon: f64) -> ResourceBudget {
+    let native = optimize(&decompose(circuit));
+    let mut budget = ResourceBudget::default();
+    let mut last_t_layer = vec![0usize; native.num_qubits];
+    for gate in &native.gates {
+        cost_native_gate(gate, epsilon, &mut budget, &mut last_t_layer);
+    }
+    budget.t_depth = last_t_layer.into_iter().max().unwrap_or(0);
+    budget
+}
+
+fn cost_native_gate(
+    gate: &NativeGate,
+    epsilon: f64,
+    budget: &mut ResourceBudget,
+    last_t_layer: &mut [usize],
+) {
+    match gate {
+        NativeGate::Rz(q, angle) | NativeGate::Ry(q, angle) => {
+            apply_rotation_cost(*q, *angle, epsilon, budget, last_t_layer);
+        }
+        NativeGate::Rzz(a, b, angle) => {
+            // Cx(a,b) . Rz(b, angle) . Cx(a,b) -- the Cxs are Clifford
+            // (counted below), the T-cost lives entirely in the middle
+            // Rz, and it's a real event on *both* wires for T-depth
+            // purposes (the CNOTs entangle them around it).
+            budget.clifford_count += 2; // the two sandwiching Cx gates
+            let cost = rotation_t_cost(*angle, epsilon);
+            record_rotation(cost, budget);
+            if cost.t_count > 0 {
+                let layer = last_t_layer[*a].max(last_t_layer[*b]) + 1;
+                last_t_layer[*a] = layer;
+                last_t_layer[*b] = layer;
+            }
+        }
+        NativeGate::Measure(..) => {
+            budget.measurement_count += 1;
+        }
+        NativeGate::If(_, inner) => {
+            // The condition itself is assumed free (see this module's
+            // doc comment on the fast-decoder assumption); `inner`
+            // costs exactly what it would unconditioned.
+            cost_native_gate(inner, epsilon, budget, last_t_layer);
+        }
+    }
+}
+
+fn apply_rotation_cost(
+    q: usize,
+    angle: f64,
+    epsilon: f64,
+    budget: &mut ResourceBudget,
+    last_t_layer: &mut [usize],
+) {
+    let cost = rotation_t_cost(angle, epsilon);
+    record_rotation(cost, budget);
+    if cost.t_count > 0 {
+        last_t_layer[q] += 1;
+    }
+}
+
+fn record_rotation(cost: RotationCost, budget: &mut ResourceBudget) {
+    budget.t_count += cost.t_count;
+    match cost.synthesis {
+        RotationSynthesis::Identity => {
+            budget.exact_rotations += 1;
+        }
+        RotationSynthesis::Clifford => {
+            budget.clifford_count += 1;
+            budget.exact_rotations += 1;
+        }
+        RotationSynthesis::ExactT => {
+            // The T/Tdg itself is in t_count already; the "up to a
+            // free Clifford correction" part of an exact synthesis is
+            // the Clifford half of that decomposition.
+            budget.clifford_count += 1;
+            budget.exact_rotations += 1;
+        }
+        RotationSynthesis::Approximate => {
+            budget.approximated_rotations += 1;
+        }
+    }
+}
+
+/// Tolerance for treating an angle as an *exact* multiple of `pi/4`
+/// (and therefore `pi/2`) rather than falling through to the
+/// asymptotic estimate. Matches `native.rs`'s own `EPS` -- the same
+/// "this many radians of floating-point slop is a rounding error, not
+/// a real angle" judgment call the rest of the crate already makes.
+const EPS_ANGLE: f64 = 1e-9;
+
+/// Classifies and costs a single rotation angle -- shared by every
+/// call site above so the exact-vs-approximate boundary is judged
+/// exactly once. See this module's doc comment for the reasoning
+/// behind each case.
+fn rotation_t_cost(theta: f64, epsilon: f64) -> RotationCost {
+    let wrapped = theta.rem_euclid(TAU);
+    let near_zero = wrapped < EPS_ANGLE || (TAU - wrapped) < EPS_ANGLE;
+    if near_zero {
+        return RotationCost { synthesis: RotationSynthesis::Identity, t_count: 0 };
+    }
+
+    let quarter_turns = wrapped / (PI / 2.0);
+    if (quarter_turns - quarter_turns.round()).abs() < EPS_ANGLE {
+        return RotationCost { synthesis: RotationSynthesis::Clifford, t_count: 0 };
+    }
+
+    let eighth_turns = wrapped / (PI / 4.0);
+    if (eighth_turns - eighth_turns.round()).abs() < EPS_ANGLE {
+        // Already excluded exact pi/2 multiples above, so surviving
+        // here means this is specifically an *odd* multiple of pi/4.
+        return RotationCost { synthesis: RotationSynthesis::ExactT, t_count: 1 };
+    }
+
+    // Ross-Selinger asymptotic optimal count: ~3*log2(1/epsilon).
+    // `epsilon` must be in (0, 1) for this to mean anything as a
+    // precision target; callers passing an invalid epsilon get a
+    // saturating fallback rather than a NaN/negative T-count.
+    let safe_epsilon = if epsilon > 0.0 && epsilon < 1.0 { epsilon } else { DEFAULT_ROTATION_EPSILON };
+    let t_count = (3.0 * (1.0 / safe_epsilon).log2()).ceil().max(1.0) as usize;
+    RotationCost { synthesis: RotationSynthesis::Approximate, t_count }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identity_angle_costs_nothing() {
+        let cost = rotation_t_cost(0.0, DEFAULT_ROTATION_EPSILON);
+        assert_eq!(cost.synthesis, RotationSynthesis::Identity);
+        assert_eq!(cost.t_count, 0);
+        // Exact 2*pi should be treated the same as exact 0.
+        let cost2 = rotation_t_cost(TAU, DEFAULT_ROTATION_EPSILON);
+        assert_eq!(cost2.synthesis, RotationSynthesis::Identity);
+    }
+
+    #[test]
+    fn pi_over_2_multiples_are_clifford() {
+        for k in [1, 2, 3, -1, -2] {
+            let cost = rotation_t_cost(k as f64 * PI / 2.0, DEFAULT_ROTATION_EPSILON);
+            assert_eq!(
+                cost.synthesis,
+                RotationSynthesis::Clifford,
+                "angle {} * pi/2 should be exact Clifford",
+                k
+            );
+            assert_eq!(cost.t_count, 0);
+        }
+    }
+
+    #[test]
+    fn odd_pi_over_4_multiples_cost_exactly_one_t() {
+        for k in [1, 3, 5, 7, -1, -3] {
+            let cost = rotation_t_cost(k as f64 * PI / 4.0, DEFAULT_ROTATION_EPSILON);
+            assert_eq!(
+                cost.synthesis,
+                RotationSynthesis::ExactT,
+                "angle {} * pi/4 should be exact T/Tdg",
+                k
+            );
+            assert_eq!(cost.t_count, 1);
+        }
+    }
+
+    #[test]
+    fn generic_angle_uses_the_asymptotic_estimate_and_shrinks_with_epsilon() {
+        let loose = rotation_t_cost(0.123456, 1e-3);
+        let tight = rotation_t_cost(0.123456, 1e-12);
+        assert_eq!(loose.synthesis, RotationSynthesis::Approximate);
+        assert_eq!(tight.synthesis, RotationSynthesis::Approximate);
+        assert!(
+            tight.t_count > loose.t_count,
+            "a tighter epsilon should never cost fewer T gates: loose={} tight={}",
+            loose.t_count,
+            tight.t_count
+        );
+    }
+
+    #[test]
+    fn invalid_epsilon_falls_back_rather_than_producing_nonsense() {
+        let cost = rotation_t_cost(0.123456, -1.0);
+        assert_eq!(cost.synthesis, RotationSynthesis::Approximate);
+        assert!(cost.t_count > 0);
+    }
+
+    #[test]
+    fn h_gate_is_pure_clifford_zero_t_count() {
+        let mut c = Circuit::new(1);
+        c.push(Gate::H(0));
+        let budget = estimate_circuit_resources(&c);
+        assert_eq!(budget.t_count, 0);
+        assert!(budget.clifford_count > 0);
+    }
+
+    #[test]
+    fn t_gate_costs_exactly_one_t() {
+        let mut c = Circuit::new(1);
+        c.push(Gate::T(0));
+        let budget = estimate_circuit_resources(&c);
+        assert_eq!(budget.t_count, 1);
+    }
+
+    #[test]
+    fn arbitrary_rotation_costs_more_than_zero_t() {
+        let mut c = Circuit::new(1);
+        c.push(Gate::Rz(0, 0.123456));
+        let budget = estimate_circuit_resources(&c);
+        assert!(budget.t_count > 0);
+        assert_eq!(budget.approximated_rotations, 1);
+    }
+
+    #[test]
+    fn cx_is_free_two_qubit_rzz_costs_one_rotations_worth() {
+        let mut c = Circuit::new(2);
+        c.push(Gate::Cx(0, 1));
+        let cx_budget = estimate_circuit_resources(&c);
+        assert_eq!(cx_budget.t_count, 0);
+
+        let mut c2 = Circuit::new(2);
+        c2.push(Gate::Rzz(0, 1, 0.123456));
+        let rzz_budget = estimate_circuit_resources(&c2);
+        let single_rotation = rotation_t_cost(0.123456, DEFAULT_ROTATION_EPSILON).t_count;
+        assert_eq!(rzz_budget.t_count, single_rotation);
+    }
+
+    #[test]
+    fn measure_costs_zero_t_but_is_tracked_separately() {
+        let mut c = Circuit::new(1);
+        c.num_clbits = 1;
+        c.push(Gate::Measure(0, 0));
+        let budget = estimate_circuit_resources(&c);
+        assert_eq!(budget.t_count, 0);
+        assert_eq!(budget.measurement_count, 1);
+    }
+
+    #[test]
+    fn conditioned_gate_costs_the_same_as_unconditioned() {
+        let mut plain = Circuit::new(1);
+        plain.push(Gate::Rz(0, 0.123456));
+        let plain_budget = estimate_circuit_resources(&plain);
+
+        let mut conditioned = Circuit::new(2);
+        conditioned.num_clbits = 1;
+        conditioned.push(Gate::If(vec![(0, true)], Box::new(Gate::Rz(1, 0.123456))));
+        let conditioned_budget = estimate_circuit_resources(&conditioned);
+
+        assert_eq!(plain_budget.t_count, conditioned_budget.t_count);
+    }
+
+    #[test]
+    fn t_depth_counts_sequential_t_layers_not_total_t_count() {
+        // Two T gates on the SAME qubit, in sequence, with an
+        // intervening gate on a DIFFERENT qubit so merge_pass can't
+        // fuse them (adjacent-same-qubit T . T = S is a real,
+        // physically correct fusion this estimate correctly benefits
+        // from -- see the note below -- so this test has to actually
+        // prevent that fusion to test what it means to test).
+        let mut sequential = Circuit::new(2);
+        sequential.push(Gate::T(0)).push(Gate::X(1)).push(Gate::T(0));
+        let seq_budget = estimate_circuit_resources(&sequential);
+        assert_eq!(seq_budget.t_count, 2);
+        assert_eq!(seq_budget.t_depth, 2);
+
+        // Two T gates on DIFFERENT qubits -> t_depth 1 (parallel).
+        let mut parallel = Circuit::new(2);
+        parallel.push(Gate::T(0)).push(Gate::T(1));
+        let par_budget = estimate_circuit_resources(&parallel);
+        assert_eq!(par_budget.t_count, 2);
+        assert_eq!(par_budget.t_depth, 1);
+    }
+
+    #[test]
+    fn adjacent_same_qubit_t_gates_genuinely_fuse_to_a_clifford() {
+        // T . T == S exactly (both are Rz(pi/4) up to phase, and
+        // Rz(pi/4) . Rz(pi/4) == Rz(pi/2) == S). optimize()'s own
+        // merge_pass performs exactly this fusion since it merges any
+        // two adjacent same-qubit Rz's regardless of the resulting
+        // angle -- and estimate_circuit_resources runs that same
+        // optimize() before costing anything (see this module's own
+        // doc comment on why), so it should report this correctly as
+        // 0 T gates, not 2. A naive per-source-gate estimator that
+        // summed each T's cost independently would get this wrong.
+        let mut c = Circuit::new(1);
+        c.push(Gate::T(0)).push(Gate::T(0));
+        let budget = estimate_circuit_resources(&c);
+        assert_eq!(budget.t_count, 0, "adjacent T.T should fuse to S (Clifford) before costing");
+    }
+
+    #[test]
+    fn tighter_epsilon_never_decreases_t_count_for_a_whole_circuit() {
+        let mut c = Circuit::new(1);
+        c.push(Gate::Rz(0, 0.7)).push(Gate::Ry(0, 1.9));
+        let loose = estimate_circuit_resources_with_epsilon(&c, 1e-2);
+        let tight = estimate_circuit_resources_with_epsilon(&c, 1e-15);
+        assert!(tight.t_count >= loose.t_count);
+    }
+}

--- a/src/route.rs
+++ b/src/route.rs
@@ -2913,10 +2913,12 @@ fn remap_single(gate: &Gate, new_q: usize) -> Gate {
         // `If`'s own qubit(s) are wherever `inner`'s are (see
         // `Gate::qubits`), so remapping it means recursing into
         // `inner` with the same `remap_single`/`remap_two` split the
-        // caller already used to get here -- `clbit`/`value` are
+        // caller already used to get here -- `conditions` are
         // classical, untouched by routing, same as `Measure`'s `c`
         // above.
-        If(clbit, value, ref inner) => If(clbit, value, Box::new(remap_single(inner, new_q))),
+        If(ref conditions, ref inner) => {
+            If(conditions.clone(), Box::new(remap_single(inner, new_q)))
+        }
         _ => unreachable!("remap_single called on a two-qubit gate"),
     }
 }
@@ -2931,8 +2933,8 @@ fn remap_two(gate: &Gate, new_first: usize, new_second: usize) -> Gate {
         Ryy(_, _, t) => Ryy(new_first, new_second, t),
         Rzz(_, _, t) => Rzz(new_first, new_second, t),
         Cp(_, _, l) => Cp(new_first, new_second, l),
-        If(clbit, value, ref inner) => {
-            If(clbit, value, Box::new(remap_two(inner, new_first, new_second)))
+        If(ref conditions, ref inner) => {
+            If(conditions.clone(), Box::new(remap_two(inner, new_first, new_second)))
         }
         _ => unreachable!("remap_two called on a single-qubit gate"),
     }

--- a/src/sequencer.rs
+++ b/src/sequencer.rs
@@ -1,0 +1,1273 @@
+//! Real-time control-flow program: the layer between [`crate::pulse`]'s
+//! static [`Schedule`](crate::pulse::Schedule) and an actual piece of
+//! control electronics. This is the module `pulse.rs`'s own doc
+//! comment on `BackendGate::If` points to -- the thing that closes
+//! the gap that module deliberately leaves open ("this static
+//! `Schedule` only ever describes which pulses exist and when, never
+//! whether one actually fires at runtime").
+//!
+//! # Why this is a separate layer, not a `Schedule` extension
+//! A [`Schedule`](crate::pulse::Schedule) is a flat, precomputed list
+//! of pulses with fixed start times -- exactly what you get from
+//! compiling a circuit *offline*, with no notion of "wait and see."
+//! Real classical feed-forward (read a qubit, branch on the result,
+//! all within the coherence time budget) is not a data format
+//! difference from that -- it's a different *kind* of artifact: a
+//! program with real registers and real jumps, meant to run on a
+//! sequencer that can evaluate a comparison and change what it does
+//! next inside a single shot. Bolting a condition field onto
+//! `PulseInstruction::Play` wouldn't represent that; it would just
+//! move the same "trust me, this fires unconditionally" gap one field
+//! deeper. [`Program`] is a real, separate representation instead.
+//!
+//! # What's real here today, and what's deliberately not
+//! [`compile`] is real: it walks an already-lowered
+//! [`BackendCircuit`](crate::backend::BackendCircuit) (the same input
+//! [`crate::pulse::schedule`] takes) and produces a [`Program`] whose
+//! branch structure is checked -- not just asserted -- against
+//! `ir::Gate::If`'s own semantics (see `tests` below: for every
+//! possible combination of measurement outcomes, the set of pulses
+//! [`Program`]'s branches select is proven to match what
+//! `emit::run_backend_with_measurement`'s direct conditional
+//! evaluation would apply).
+//!
+//! What's deliberately *not* here yet is anything vendor-specific.
+//! [`HardwareTarget`] is the extension point a real control-electronics
+//! backend implements -- one trait, one file per vendor, the same
+//! pattern [`crate::backend::BackendSpec`] already established for
+//! per-vendor gate sets (see that module's own doc comment for the
+//! rationale, which applies here unchanged). No implementation of it
+//! ships in this crate today, because guessing at a vendor's real
+//! instruction set, branch-latency model, or register file from
+//! marketing material would produce exactly the kind of silently-wrong
+//! artifact this crate's own conventions elsewhere refuse to produce
+//! (see e.g. `ibm_export.rs`'s explicit `Err` on `BackendGate::If`,
+//! for the same reason). [`Program`] is written to be a *reasonable*
+//! lowering target regardless of which vendor eventually implements
+//! against it -- a flat instruction list, one classical register per
+//! source clbit, and a single branching primitive
+//! ([`SeqInstr::JumpIfEqual`], compare-a-register-to-an-immediate-and-
+//! jump) that nearly every real sequencer ISA either has directly or
+//! is trivially built from (Quantum Machines' QUA has `if_`/`while_`;
+//! Zurich Instruments' SeqC has native `if`/`while`; Keysight PathWave
+//! has branch instructions in its own sequencer language) -- but it is
+//! still, honestly, an unvalidated guess at the right shape until a
+//! real vendor's actual documentation is in hand to check it against.
+//!
+//! # `execute`: the other half of "real," today
+//! [`compile`]'s own correctness test proves [`Program`]'s *branch
+//! structure* is faithful to `Gate::If`'s semantics -- which pulse a
+//! given outcome selects -- but says nothing about whether the
+//! resulting *quantum state* is right. [`execute`] closes that gap:
+//! it interprets a compiled [`Program`] against a real
+//! `sirraya_qutub::core::QuantumRegister`, with genuine Born-rule
+//! measurement collapse (via `QuantumRegister::measure_single_qubit`)
+//! feeding the sequencer's own real-time registers and genuine
+//! branching on those real outcomes. See [`execute`]'s own doc comment
+//! for exactly what this does and does not verify -- in short, it
+//! proves `Program`'s pulse-level representation reproduces the same
+//! physics as executing the `BackendCircuit` directly
+//! (`emit::run_backend_with_measurement`), not that a real waveform
+//! achieves its intended rotation (that remains `waveform_sim.rs`'s
+//! job, and its own two-qubit gap stays open here too).
+
+use crate::backend::{Backend, BackendCircuit, BackendGate, NativeTwoQubitGate};
+use crate::pulse::{push_leaf_pulse, Channel, PulseCalibration, PulseInstruction};
+use sirraya_qutub::core::QuantumRegister;
+use std::collections::HashMap;
+use std::f64::consts::PI;
+
+/// One instruction in a real-time sequencer [`Program`]. Every variant
+/// here corresponds to something a real control-electronics ISA
+/// actually needs to express -- this is deliberately *not* a 1:1
+/// mirror of [`crate::ir::Gate`]/[`BackendGate`]; it's one level closer
+/// to the hardware, the same way [`PulseInstruction`] already is for
+/// the unconditional case.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SeqInstr {
+    /// Emit a physical pulse -- unconditionally, from the sequencer's
+    /// point of view. Conditionality is expressed by *skipping over*
+    /// a `Play` with [`SeqInstr::JumpIfEqual`], not by a field on
+    /// `Play` itself -- see this module's doc comment on why a
+    /// condition field on the instruction wouldn't be the real thing.
+    Play(PulseInstruction),
+    /// Triggers a readout on `qubit` and writes the digitized
+    /// single-bit outcome into real-time register `reg`. This has no
+    /// counterpart in [`crate::pulse::Schedule`] at all -- a static
+    /// schedule only ever describes *playing* the readout pulse
+    /// ([`SeqInstr::Play`] handles that half); *capturing* its result
+    /// into something later instructions can branch on is a genuinely
+    /// new capability this layer adds.
+    MeasureInto { qubit: usize, reg: usize },
+    /// If register `reg`'s current value equals `value`, jump to
+    /// instruction index `target`; otherwise fall through to the next
+    /// instruction. The one branching primitive this whole module is
+    /// built around -- see the module doc comment for why this
+    /// specific shape (compare-immediate-and-jump) rather than a
+    /// richer condition language.
+    JumpIfEqual { reg: usize, value: u8, target: usize },
+    /// Unconditional jump, used to skip *around* a conditioned block
+    /// when the condition is `false`-triggered (see [`compile`]).
+    Jump { target: usize },
+    /// End of program.
+    Halt,
+}
+
+/// A real-time, branching program compiled from an already-lowered
+/// [`BackendCircuit`] -- see this module's doc comment for where this
+/// sits in the pipeline and what it's for.
+#[derive(Debug, Clone)]
+pub struct Program {
+    pub backend: Backend,
+    pub instrs: Vec<SeqInstr>,
+    /// One real-time classical register per source classical bit --
+    /// `num_registers == circuit.num_clbits` of the `BackendCircuit`
+    /// this was compiled from. A [`SeqInstr::MeasureInto`] writes one;
+    /// a [`SeqInstr::JumpIfEqual`] reads one.
+    pub num_registers: usize,
+}
+
+/// Compiles an already-lowered [`BackendCircuit`] into a real-time
+/// [`Program`]. Reuses [`crate::pulse::push_leaf_pulse`] for every leaf
+/// gate's actual pulse -- the exact same physical-pulse construction
+/// [`crate::pulse::schedule`] uses for its own (unconditional) output,
+/// so the two layers never disagree about what pulse a given gate
+/// produces, only about whether/when it's allowed to fire. A
+/// `BackendGate::If(clbit, value, inner)` compiles to a real
+/// conditional skip: jump past `inner`'s instruction(s) if the
+/// register doesn't hold the required value, otherwise fall through
+/// and execute them -- see [`SeqInstr::JumpIfEqual`]'s doc comment.
+pub fn compile(circuit: &BackendCircuit, cal: &PulseCalibration) -> Result<Program, String> {
+    if circuit.backend != cal.backend {
+        return Err(format!(
+            "calibration is for {:?} but circuit was lowered for {:?}",
+            cal.backend, circuit.backend
+        ));
+    }
+
+    let mut busy_until: HashMap<usize, f64> = HashMap::new();
+    let mut instrs = Vec::with_capacity(circuit.gates.len());
+
+    for g in &circuit.gates {
+        compile_one(g, cal, &mut busy_until, &mut instrs)?;
+    }
+    instrs.push(SeqInstr::Halt);
+
+    Ok(Program { backend: circuit.backend, instrs, num_registers: circuit.num_clbits })
+}
+
+fn compile_one(
+    g: &BackendGate,
+    cal: &PulseCalibration,
+    busy_until: &mut HashMap<usize, f64>,
+    instrs: &mut Vec<SeqInstr>,
+) -> Result<(), String> {
+    match *g {
+        BackendGate::Measure(q, c) => {
+            let mut plays = Vec::new();
+            push_leaf_pulse(g, cal, busy_until, &mut plays)?;
+            instrs.extend(plays.into_iter().map(SeqInstr::Play));
+            instrs.push(SeqInstr::MeasureInto { qubit: q, reg: c });
+        }
+        BackendGate::If(ref conditions, ref inner) => {
+            // Skip past inner's instructions unless *every* condition
+            // holds (AND semantics -- see `ir::Gate::If`'s doc
+            // comment): one JumpIfEqual per condition, each jumping to
+            // the same "after inner" target if that condition's own
+            // register does NOT hold the required value (hence each
+            // jump's own `value` is the *negation* of its condition's
+            // `value`). If every jump falls through, every condition
+            // held, and inner executes.
+            let mut jump_indices = Vec::with_capacity(conditions.len());
+            for &(clbit, value) in conditions {
+                let negated = if value { 0 } else { 1 };
+                jump_indices.push(instrs.len());
+                // Placeholder target, patched below once inner's real
+                // instruction count is known -- avoids a two-pass
+                // compile.
+                instrs.push(SeqInstr::JumpIfEqual {
+                    reg: clbit,
+                    value: negated,
+                    target: usize::MAX,
+                });
+            }
+            compile_one(inner, cal, busy_until, instrs)?;
+            let after = instrs.len();
+            for jump_idx in jump_indices {
+                if let SeqInstr::JumpIfEqual { target, .. } = &mut instrs[jump_idx] {
+                    *target = after;
+                }
+            }
+        }
+        _ => {
+            let mut plays = Vec::new();
+            push_leaf_pulse(g, cal, busy_until, &mut plays)?;
+            instrs.extend(plays.into_iter().map(SeqInstr::Play));
+        }
+    }
+    Ok(())
+}
+
+/// Executes a compiled [`Program`] against a real
+/// `sirraya_qutub::core::QuantumRegister` -- genuine Born-rule
+/// measurement collapse feeding the sequencer's own real-time
+/// registers, and genuine branching on those real outcomes. Not a
+/// structural/symbolic check the way this module's own
+/// `branch_structure_matches_...` test is (see that test's doc
+/// comment) -- the real thing, held to the same "checked against the
+/// real simulator, not asserted" standard every other rewrite in this
+/// crate is (`native.rs`'s decompositions, `route.rs`'s SWAP
+/// insertion, `optimize_ir`'s cancellation -- see
+/// `tests/decompositions.rs`, `examples/verify_equivalence.rs`).
+///
+/// # What this proves, and what it deliberately doesn't
+/// This proves `Program`'s *control flow* -- which pulse fires, gated
+/// on which real measurement outcome -- reproduces the exact same
+/// final quantum state `emit::run_backend_with_measurement` gives for
+/// the same `BackendCircuit`. It does this by recovering each
+/// `Play`/`ShiftPhase` instruction's underlying gate action from its
+/// pulse parameters -- the exact inverse of how [`push_leaf_pulse`]
+/// constructed them, lossless, not an approximation -- and applying
+/// that action directly to the register, rather than numerically
+/// integrating the actual waveform envelope against a driven
+/// Hamiltonian. That deeper check -- does the *waveform itself*
+/// achieve the intended rotation -- is `waveform_sim.rs`'s job, which
+/// already covers the single-qubit case and explicitly, honestly
+/// leaves two-qubit gates as separate, unimplemented follow-on work
+/// (see that module's own doc comment). Conflating the two here would
+/// mean silently claiming a stronger result than either module
+/// actually establishes.
+///
+/// Returns the final register and the classical outcomes every
+/// `SeqInstr::MeasureInto` wrote, indexed by register -- the same
+/// shape [`crate::emit::run_backend_with_measurement`] returns, so a
+/// caller can compare the two directly.
+pub fn execute(
+    circuit: &BackendCircuit,
+    program: &Program,
+    cal: &PulseCalibration,
+) -> Result<(QuantumRegister, Vec<u8>), String> {
+    execute_impl(circuit, program, cal, None, None, &mut || 0.0)
+}
+
+/// As [`execute`], but every classical bit a `SeqInstr::MeasureInto`
+/// writes is passed through `readout_cal`'s confusion probabilities
+/// (see [`crate::readout`]) before being stored in the sequencer's own
+/// register and returned -- modeling a real, imperfect classical
+/// readout chain layered independently on top of the exact quantum
+/// collapse `QuantumRegister::measure_single_qubit` still performs.
+///
+/// # A real, checkable consequence
+/// Because `Gate::If`/`SeqInstr::JumpIfEqual` branch on exactly the
+/// value this function writes to a register -- never on the qubit's
+/// true post-measurement state directly -- a corrupted readout can
+/// make a conditioned correction fire when it shouldn't (or skip when
+/// it should have fired), even though the underlying quantum collapse
+/// was exact. This is real, physical behavior, not a modeling
+/// artifact: it's exactly why a real feed-forward protocol's fidelity
+/// budget needs to include readout error alongside gate error, not
+/// gate error alone (see this module's own test,
+/// `readout_noise_can_break_a_correction_decision`, for a checked
+/// demonstration on the teleportation circuit).
+///
+/// A thin wrapper over [`execute_with_noise`] with no gate noise --
+/// kept as its own named function since "readout error only" is a
+/// common, meaningful configuration on its own (e.g. isolating its
+/// effect from gate error the way this module's own tests do).
+///
+/// `uniform_samples` supplies one U[0, 1) value per `MeasureInto`
+/// executed, in the order they execute -- see
+/// [`crate::readout::corrupt_readout`]'s doc comment for why this
+/// crate's library code takes randomness this way rather than
+/// depending on an RNG crate directly.
+pub fn execute_with_readout_noise(
+    circuit: &BackendCircuit,
+    program: &Program,
+    cal: &PulseCalibration,
+    readout_cal: &crate::readout::ReadoutCalibration,
+    uniform_samples: impl FnMut() -> f64,
+) -> Result<(QuantumRegister, Vec<u8>), String> {
+    execute_with_noise(circuit, program, cal, None, Some(readout_cal), uniform_samples)
+}
+
+/// The full, combined noisy execution: real per-gate depolarizing
+/// noise (see [`crate::noise`]) *and* real classical readout error
+/// (see [`crate::readout`]), together, on top of the same exact
+/// interpretation [`execute`] performs. Either noise source can be
+/// turned off independently by passing `None` -- `execute` itself is
+/// exactly `execute_with_noise(.., None, None, ..)`, and
+/// [`execute_with_readout_noise`] is exactly `execute_with_noise(..,
+/// None, Some(readout_cal), ..)`.
+///
+/// `gate_cal` prices depolarizing noise for every *real physical*
+/// pulse (`Channel::Drive`/`Channel::Control` `Play` instructions) --
+/// deliberately never for a virtual-Z `ShiftPhase`, which has
+/// essentially zero real gate error on real hardware (that's the whole
+/// point of implementing `Rz` that way). This is a more physically
+/// precise choice than `fidelity::estimate_circuit_fidelity`'s own
+/// gate-counting, which prices `Rz` the same as `Ry` purely for the
+/// simplicity of a quick aggregate estimate -- see `noise.rs`'s own
+/// doc comment. A two-qubit `Play` samples an independent error on
+/// *each* of its two qubits, both at `gate_cal.two_qubit_error_probability()`
+/// -- a standard, simplified stand-in for a full two-qubit
+/// depolarizing channel (see `noise.rs`'s doc comment for why).
+///
+/// `uniform_samples` supplies one U[0, 1) value per noise-eligible
+/// event -- every real `Play` sampled against `gate_cal` (two draws
+/// for a two-qubit gate, one per qubit) and every `MeasureInto`
+/// sampled against `readout_cal` -- called in the exact order those
+/// events occur during execution, so a fixed-seed RNG on the caller's
+/// side gives a fully reproducible noisy trajectory.
+pub fn execute_with_noise(
+    circuit: &BackendCircuit,
+    program: &Program,
+    cal: &PulseCalibration,
+    gate_cal: Option<&crate::fidelity::PublishedCalibration>,
+    readout_cal: Option<&crate::readout::ReadoutCalibration>,
+    mut uniform_samples: impl FnMut() -> f64,
+) -> Result<(QuantumRegister, Vec<u8>), String> {
+    execute_impl(circuit, program, cal, gate_cal, readout_cal, &mut uniform_samples)
+}
+
+/// The shared core every `execute*` function runs -- identical except
+/// for whether `gate_cal`/`readout_cal` are `Some`, in which case the
+/// corresponding noise is sampled from `uniform_samples` at exactly
+/// the point it physically occurs. Factoring it this way (rather than
+/// duplicating the whole interpreter loop per noise configuration)
+/// means every variant can never quietly drift apart on anything
+/// *except* those two, explicit differences.
+fn execute_impl(
+    circuit: &BackendCircuit,
+    program: &Program,
+    cal: &PulseCalibration,
+    gate_cal: Option<&crate::fidelity::PublishedCalibration>,
+    readout_cal: Option<&crate::readout::ReadoutCalibration>,
+    uniform_samples: &mut dyn FnMut() -> f64,
+) -> Result<(QuantumRegister, Vec<u8>), String> {
+    if circuit.backend != program.backend {
+        return Err(format!(
+            "execute: program was compiled for {:?} but circuit was lowered for {:?}",
+            program.backend, circuit.backend
+        ));
+    }
+    if circuit.backend != cal.backend {
+        return Err(format!(
+            "execute: calibration is for {:?} but circuit was lowered for {:?}",
+            cal.backend, circuit.backend
+        ));
+    }
+
+    let mut reg = QuantumRegister::new(circuit.num_qubits)?;
+    let mut registers: Vec<Option<u8>> = vec![None; program.num_registers];
+    let mut clbits = vec![0u8; program.num_registers];
+    let axis = circuit.backend.rot_axis();
+
+    let mut pc = 0usize;
+    // A well-formed Program (everything `compile` produces) only ever
+    // jumps forward, so this bound is generous, not tight -- it's here
+    // to turn a hypothetical compiler bug that emits a backward jump
+    // into a clear error instead of a hang.
+    let max_steps = program.instrs.len().saturating_mul(4).saturating_add(16);
+    let mut steps = 0usize;
+
+    // Samples one gate-noise draw for qubit `q` against `p`, applying
+    // it to `reg` if it fires. Called only from sites that already
+    // checked `gate_cal.is_some()`, so `uniform_samples` is never
+    // invoked when gate noise is off -- see `execute`'s own use of a
+    // never-invoked placeholder closure.
+    fn maybe_apply_gate_noise(
+        reg: &mut QuantumRegister,
+        q: usize,
+        p: f64,
+        sample: f64,
+    ) -> Result<(), String> {
+        if let Some(err) = crate::noise::sample_depolarizing_error(p, sample) {
+            crate::noise::apply_pauli_error(reg, q, err)?;
+        }
+        Ok(())
+    }
+
+    loop {
+        steps += 1;
+        if steps > max_steps {
+            return Err(format!(
+                "execute: exceeded {} steps without reaching Halt -- likely a backward-jumping \
+                 or otherwise malformed Program (pc={})",
+                max_steps, pc
+            ));
+        }
+        let instr = program.instrs.get(pc).ok_or_else(|| {
+            format!(
+                "execute: program counter {} out of bounds ({} instructions)",
+                pc,
+                program.instrs.len()
+            )
+        })?;
+        match instr {
+            SeqInstr::Play(PulseInstruction::ShiftPhase { channel, angle_rad, .. }) => {
+                // No gate-noise sampling here -- virtual-Z, see this
+                // function's own doc comment on `gate_cal`.
+                if let Channel::Drive(q) = *channel {
+                    reg.apply_rz(q, *angle_rad)?;
+                }
+                pc += 1;
+            }
+            SeqInstr::Play(PulseInstruction::Play { channel, amplitude, .. }) => {
+                match *channel {
+                    Channel::Drive(q) => {
+                        let theta = invert_amplitude(*amplitude, cal.rot.pi_amplitude, "rot")?;
+                        match axis {
+                            crate::backend::RotAxis::Ry => reg.apply_ry(q, theta)?,
+                            crate::backend::RotAxis::Rx => reg.apply_rx(q, theta)?,
+                        }
+                        if let Some(gc) = gate_cal {
+                            let sample = uniform_samples();
+                            maybe_apply_gate_noise(
+                                &mut reg,
+                                q,
+                                gc.single_qubit_error_probability(),
+                                sample,
+                            )?;
+                        }
+                    }
+                    Channel::Control(a, b) => {
+                        match circuit.backend.native_two_qubit_gate() {
+                            NativeTwoQubitGate::ContinuousRzz => {
+                                let rzz_cal = cal.rzz.ok_or_else(|| {
+                                    "execute: backend's native two-qubit gate is Rzz but this \
+                                     calibration has no rzz entry"
+                                        .to_string()
+                                })?;
+                                let theta =
+                                    invert_amplitude(*amplitude, rzz_cal.pi_amplitude, "rzz")?;
+                                reg.apply_rzz(a, b, theta)?;
+                            }
+                            NativeTwoQubitGate::FixedCx => reg.apply_cnot(a, b)?,
+                            NativeTwoQubitGate::FixedCz => reg.apply_controlled_z(a, b)?,
+                        }
+                        if let Some(gc) = gate_cal {
+                            let p = gc.two_qubit_error_probability();
+                            let sample_a = uniform_samples();
+                            maybe_apply_gate_noise(&mut reg, a, p, sample_a)?;
+                            let sample_b = uniform_samples();
+                            maybe_apply_gate_noise(&mut reg, b, p, sample_b)?;
+                        }
+                    }
+                    // The readout play is informational/timing only --
+                    // the actual collapse happens at the matching
+                    // MeasureInto below, via a real
+                    // measure_single_qubit call, not here. Not a
+                    // gate-noise-eligible event either (readout error
+                    // is modeled separately, via `readout_cal` below).
+                    Channel::Readout(_) => {}
+                }
+                pc += 1;
+            }
+            SeqInstr::MeasureInto { qubit, reg: r } => {
+                let true_outcome = reg.measure_single_qubit(*qubit)?;
+                let reported = match readout_cal {
+                    Some(rc) => {
+                        crate::readout::corrupt_readout(true_outcome, rc, uniform_samples())
+                    }
+                    None => true_outcome,
+                };
+                registers[*r] = Some(reported);
+                clbits[*r] = reported;
+                pc += 1;
+            }
+            SeqInstr::JumpIfEqual { reg: r, value, target } => {
+                let actual = registers[*r].ok_or_else(|| {
+                    format!(
+                        "execute: JumpIfEqual read register {} before any MeasureInto wrote it",
+                        r
+                    )
+                })?;
+                pc = if actual == *value { *target } else { pc + 1 };
+            }
+            SeqInstr::Jump { target } => pc = *target,
+            SeqInstr::Halt => break,
+        }
+    }
+
+    Ok((reg, clbits))
+}
+
+/// Inverts a pulse `amplitude` back to the rotation angle
+/// [`push_leaf_pulse`] built it from (`amplitude = pi_amplitude *
+/// theta / PI`, so `theta = amplitude * PI / pi_amplitude`) -- exact,
+/// not approximate, since the forward direction is itself an exact
+/// linear relationship with no information loss. Errors rather than
+/// dividing by ~0 for a calibration whose `pi_amplitude` is ~0, which
+/// would otherwise silently produce a nonsense (huge or NaN) angle.
+fn invert_amplitude(amplitude: f64, pi_amplitude: f64, label: &str) -> Result<f64, String> {
+    if pi_amplitude.abs() < 1e-15 {
+        return Err(format!(
+            "execute: calibration's {} pi_amplitude is ~0 -- can't invert amplitude back to \
+             an angle",
+            label
+        ));
+    }
+    Ok(amplitude * PI / pi_amplitude)
+}
+
+/// The extension point a real control-electronics backend implements
+/// to actually drive hardware from a [`Program`] -- see this module's
+/// doc comment for why nothing implements this yet, and what shape a
+/// future implementation is expected to take (one file per vendor,
+/// mirroring [`crate::backend::BackendSpec`]).
+pub trait HardwareTarget: Send + Sync {
+    /// Stable identifier, e.g. `"QuantumMachines-OPX"`,
+    /// `"ZurichInstruments-SHFQC"`. Same role as
+    /// [`crate::backend::BackendSpec::id`].
+    fn id(&self) -> &'static str;
+
+    /// The real-time feed-forward latency this target can guarantee
+    /// between a [`SeqInstr::MeasureInto`] completing and a
+    /// conditioned [`SeqInstr::Play`] it gates being able to fire --
+    /// the number that determines whether a given `Program` actually
+    /// fits inside a qubit's coherence budget on this hardware. An
+    /// implementation should report a real, measured or vendor-
+    /// published figure here, not an estimate -- this is exactly the
+    /// kind of number this crate's `fidelity.rs`/`pulse.rs` are
+    /// already careful to cite rather than guess.
+    fn feedforward_latency_ns(&self) -> f64;
+
+    /// Lowers `program` into whatever this target's real sequencer
+    /// actually consumes -- a vendor DSL string, a bytecode blob,
+    /// whatever the real hardware wants. Deliberately opaque
+    /// (`Vec<u8>`) rather than a shared struct: different vendors'
+    /// real formats have nothing in common beyond "bytes a real
+    /// instrument can load," the same reasoning `ibm_export.rs`
+    /// already applies to its own `String` (real QASM text) output.
+    fn compile_for_hardware(&self, program: &Program) -> Result<Vec<u8>, String>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend;
+    use crate::ir::{Circuit, Gate};
+    use crate::pulse::trapped_ion_pulse_calibration;
+
+    /// The teleportation shape in miniature: measure two qubits, then
+    /// two independently-conditioned corrections on a third -- the
+    /// exact pattern `examples/quantum_teleportation.rs` compiles for
+    /// real. Built through the real pipeline (`backend::lower`), not
+    /// hand-assembled, so this test exercises the same lowering path
+    /// production code does.
+    fn teleportation_shaped_circuit() -> BackendCircuit {
+        let mut c = Circuit::new(3);
+        c.num_clbits = 2;
+        c.push(Gate::Measure(0, 0));
+        c.push(Gate::Measure(1, 1));
+        c.push(Gate::If(vec![(1, true)], Box::new(Gate::X(2))));
+        c.push(Gate::If(vec![(0, true)], Box::new(Gate::Z(2))));
+        backend::lower(&c, Backend::TrappedIon)
+    }
+
+    #[test]
+    fn compile_rejects_a_calibration_backend_mismatch() {
+        let bc = teleportation_shaped_circuit();
+        assert!(compile(&bc, &crate::pulse::ibm_heron_r2_pulse_calibration()).is_err());
+    }
+
+    #[test]
+    fn num_registers_matches_source_clbits() {
+        let bc = teleportation_shaped_circuit();
+        let program = compile(&bc, &trapped_ion_pulse_calibration()).unwrap();
+        assert_eq!(program.num_registers, 2);
+    }
+
+    #[test]
+    fn program_ends_in_halt() {
+        let bc = teleportation_shaped_circuit();
+        let program = compile(&bc, &trapped_ion_pulse_calibration()).unwrap();
+        assert_eq!(program.instrs.last(), Some(&SeqInstr::Halt));
+    }
+
+    #[test]
+    fn every_jump_target_is_a_valid_in_bounds_index() {
+        // A jump landing outside the instruction list (or exactly at
+        // its own index, an infinite loop) would be a real bug in
+        // compile_one's target-patching -- checked structurally here
+        // rather than only implicitly by the symbolic-execution tests
+        // below, so a target bug shows up even for a jump that
+        // symbolic execution never actually takes.
+        let bc = teleportation_shaped_circuit();
+        let program = compile(&bc, &trapped_ion_pulse_calibration()).unwrap();
+        for (i, instr) in program.instrs.iter().enumerate() {
+            let target = match instr {
+                SeqInstr::JumpIfEqual { target, .. } | SeqInstr::Jump { target } => Some(*target),
+                _ => None,
+            };
+            if let Some(t) = target {
+                assert!(
+                    t < program.instrs.len() && t != i,
+                    "instr {} jumps to {}, which is out of bounds or a self-loop \
+                     (program has {} instructions)",
+                    i, t, program.instrs.len()
+                );
+            }
+        }
+    }
+
+    /// A minimal symbolic interpreter: walks `program`'s control flow
+    /// for one fixed set of classical outcomes (as if a real ADC had
+    /// already digitized them) and returns which qubits received a
+    /// *drive* pulse (`Channel::Drive`, i.e. a real single-qubit gate
+    /// -- readout plays are excluded since every branch of every test
+    /// circuit here always measures the same qubits regardless of the
+    /// outcome, so they're not the interesting signal). This doesn't
+    /// simulate real quantum state or real waveforms -- see this
+    /// module's doc comment on what `compile`'s correctness claim
+    /// actually covers -- it only proves the *branch structure* is
+    /// faithful to `Gate::If`'s own semantics.
+    fn symbolic_run(program: &Program, clbit_outcomes: &[u8]) -> Vec<usize> {
+        let mut fired = Vec::new();
+        let mut registers: Vec<Option<u8>> = vec![None; program.num_registers];
+        let mut pc = 0usize;
+        let mut steps = 0usize;
+        loop {
+            steps += 1;
+            assert!(steps < 10_000, "symbolic_run: probable infinite loop, pc={}", pc);
+            match &program.instrs[pc] {
+                // Only a real `Play` counts as "fired" -- `ShiftPhase`
+                // is a virtual, zero-duration frame update (see
+                // `pulse.rs`'s own doc comment on virtual-Z) that
+                // shares `Play`'s `Channel::Drive` addressing but isn't
+                // a physical event, so it's excluded here rather than
+                // conflated with one.
+                SeqInstr::Play(PulseInstruction::Play { channel, .. }) => {
+                    if let crate::pulse::Channel::Drive(q) = *channel {
+                        fired.push(q);
+                    }
+                    pc += 1;
+                }
+                SeqInstr::Play(PulseInstruction::ShiftPhase { .. }) => pc += 1,
+                SeqInstr::MeasureInto { reg, .. } => {
+                    registers[*reg] = Some(clbit_outcomes[*reg]);
+                    pc += 1;
+                }
+                SeqInstr::JumpIfEqual { reg, value, target } => {
+                    let actual = registers[*reg]
+                        .expect("JumpIfEqual read a register no prior MeasureInto wrote");
+                    pc = if actual == *value { *target } else { pc + 1 };
+                }
+                SeqInstr::Jump { target } => pc = *target,
+                SeqInstr::Halt => break,
+            }
+        }
+        fired
+    }
+
+    /// Direct evaluation of `BackendGate::If`'s own semantics against
+    /// the *same* `BackendCircuit` [`compile`] actually consumed --
+    /// deliberately at this granularity, not the source `Circuit`'s,
+    /// since native decomposition can expand one logical gate (e.g.
+    /// `X`) into more than one native/backend gate, each independently
+    /// `If`-wrapped (see `NativeGate::If`'s doc comment) -- comparing
+    /// against the coarser source level would conflate "one logical
+    /// correction" with "one real pulse," which aren't the same
+    /// number once decomposition is in the picture. Only
+    /// `BackendGate::Rot`/`Cx`/`Cz`/`Rzz` produce a real
+    /// `PulseInstruction::Play`; `Rz` is `ShiftPhase`-only (virtual,
+    /// see `symbolic_run`'s matching exclusion), so it contributes no
+    /// qubit here either -- the two functions must agree on that
+    /// distinction for this comparison to mean anything.
+    fn expected_fired(circuit: &BackendCircuit, clbit_outcomes: &[u8]) -> Vec<usize> {
+        let mut expected = Vec::new();
+        for gate in &circuit.gates {
+            if let BackendGate::If(conditions, inner) = gate {
+                let actual = conditions
+                    .iter()
+                    .all(|&(clbit, value)| (clbit_outcomes[clbit] != 0) == value);
+                if actual {
+                    match inner.as_ref() {
+                        BackendGate::Rot(q, _) => expected.push(*q),
+                        BackendGate::Cx(a, b) | BackendGate::Cz(a, b) | BackendGate::Rzz(a, b, _) => {
+                            expected.push(*a);
+                            expected.push(*b);
+                        }
+                        BackendGate::Rz(..) => {} // virtual only, no real Play
+                        BackendGate::Measure(..) | BackendGate::If(..) => unreachable!(
+                            "BackendGate::If never wraps Measure or another If"
+                        ),
+                    }
+                }
+            }
+        }
+        expected
+    }
+
+    #[test]
+    fn branch_structure_matches_gate_if_semantics_for_every_outcome_combination() {
+        // The real correctness claim: for all four possible outcomes
+        // of the two measurements (0/0, 0/1, 1/0, 1/1), the set of
+        // qubits that receive a real drive pulse when the compiled
+        // Program is symbolically executed must exactly match what
+        // directly evaluating BackendGate::If's condition against the
+        // same outcomes (at the same BackendCircuit granularity
+        // compile() consumed) says should happen -- not asserted,
+        // checked, the same way native.rs's decompositions are checked
+        // against the real simulator rather than trusted algebraically.
+        let mut source = Circuit::new(3);
+        source.num_clbits = 2;
+        source.push(Gate::Measure(0, 0));
+        source.push(Gate::Measure(1, 1));
+        source.push(Gate::If(vec![(1, true)], Box::new(Gate::X(2))));
+        source.push(Gate::If(vec![(0, true)], Box::new(Gate::Z(2))));
+
+        let bc = backend::lower(&source, Backend::TrappedIon);
+        let program = compile(&bc, &trapped_ion_pulse_calibration()).unwrap();
+
+        for m0 in [0u8, 1] {
+            for m1 in [0u8, 1] {
+                let outcomes = [m0, m1];
+                let mut fired = symbolic_run(&program, &outcomes);
+                let mut expected = expected_fired(&bc, &outcomes);
+                fired.sort();
+                expected.sort();
+                assert_eq!(
+                    fired, expected,
+                    "outcomes m0={} m1={}: Program fired drive pulses on {:?}, but \
+                     BackendGate::If semantics say it should have been {:?}",
+                    m0, m1, fired, expected
+                );
+            }
+        }
+    }
+
+    /// The real physics check this module's doc comment promises:
+    /// runs the teleportation protocol -- entangling circuit, both
+    /// measurements, both conditioned corrections -- entirely through
+    /// `compile` + `execute`, i.e. driven by pulse-level `Program`
+    /// instructions and genuine Born-rule collapse, not by directly
+    /// evaluating `BackendGate::If` the way `emit.rs` does. Bob's
+    /// qubit should still end up in the target state with ~100%
+    /// fidelity on every trial, for every input state -- exactly the
+    /// methodology `examples/quantum_teleportation.rs` already applies
+    /// one layer up (at the `BackendCircuit`/`emit.rs` level), run
+    /// here instead against `Program`'s own pulse-level execution.
+    /// This is what actually proves `execute`'s amplitude-inversion
+    /// (`Rot`/`Rzz` angle recovery, `NativeTwoQubitGate` dispatch) is
+    /// physically correct, not just structurally plausible --
+    /// `branch_structure_matches_...` above only checks *which* qubit
+    /// gets touched, never whether the resulting quantum state is
+    /// right.
+    #[test]
+    fn execute_teleports_correctly_across_many_trials_and_every_input_state() {
+        use sirraya_qutub::DensityMatrix;
+
+        fn teleportation_circuit(prep: impl Fn(&mut Circuit)) -> Circuit {
+            let mut c = Circuit::new(3);
+            prep(&mut c);
+            c.push(Gate::H(1));
+            c.push(Gate::Cx(1, 2));
+            c.push(Gate::Cx(0, 1));
+            c.push(Gate::H(0));
+            c.num_clbits = 2;
+            c.push(Gate::Measure(0, 0));
+            c.push(Gate::Measure(1, 1));
+            c.push(Gate::If(vec![(1, true)], Box::new(Gate::X(2))));
+            c.push(Gate::If(vec![(0, true)], Box::new(Gate::Z(2))));
+            c
+        }
+
+        fn target_density_matrix(prep: impl Fn(&mut QuantumRegister)) -> DensityMatrix {
+            let mut reg = QuantumRegister::new(1).unwrap();
+            prep(&mut reg);
+            reg.to_density_matrix().unwrap()
+        }
+
+        // Six input states, matching quantum_teleportation.rs's own
+        // coverage (trimmed to four representative ones here, since
+        // this test's job is proving execute()'s physics is right,
+        // not re-running quantum_teleportation.rs's own full sweep).
+        let cases: Vec<(&str, fn(&mut Circuit), fn(&mut QuantumRegister))> = vec![
+            ("|0>", |_c: &mut Circuit| {}, |_r: &mut QuantumRegister| {}),
+            (
+                "|1>",
+                |c: &mut Circuit| {
+                    c.push(Gate::X(0));
+                },
+                |r: &mut QuantumRegister| {
+                    r.apply_pauli_x(0).unwrap();
+                },
+            ),
+            (
+                "|+>",
+                |c: &mut Circuit| {
+                    c.push(Gate::H(0));
+                },
+                |r: &mut QuantumRegister| {
+                    r.apply_hadamard(0).unwrap();
+                },
+            ),
+            (
+                "Ry(0.7)Rz(1.3)|0>",
+                |c: &mut Circuit| {
+                    c.push(Gate::Rz(0, 1.3));
+                    c.push(Gate::Ry(0, 0.7));
+                },
+                |r: &mut QuantumRegister| {
+                    r.apply_rz(0, 1.3).unwrap();
+                    r.apply_ry(0, 0.7).unwrap();
+                },
+            ),
+        ];
+
+        let cal = trapped_ion_pulse_calibration();
+
+        for (label, prep_circuit, prep_reg) in cases {
+            let source = teleportation_circuit(prep_circuit);
+            let bc = backend::lower(&source, Backend::TrappedIon);
+            let program = compile(&bc, &cal).unwrap();
+            let target = target_density_matrix(prep_reg);
+
+            for trial in 0..20 {
+                let (reg, _clbits) = execute(&bc, &program, &cal).unwrap();
+                let bob = reg.to_density_matrix().unwrap().partial_trace(&[2]).unwrap();
+                let fidelity = bob.fidelity(&target).unwrap();
+                assert!(
+                    (fidelity - 1.0).abs() < 1e-9,
+                    "state {} trial {}: teleportation via sequencer::execute should reach \
+                     ~100% fidelity, got {}",
+                    label, trial, fidelity
+                );
+            }
+        }
+    }
+
+    /// `execute_teleports_correctly_across_many_trials_and_every_input_state`
+    /// above only exercises `Backend::TrappedIon`, whose native
+    /// two-qubit gate is `Rzz` (`NativeTwoQubitGate::ContinuousRzz`).
+    /// This test is specifically for the other half of that dispatch --
+    /// `IbmQ` (`FixedCx`) and `Rigetti`/`Google` (`FixedCz`) -- the
+    /// exact ambiguity `NativeTwoQubitGate` exists to resolve (see its
+    /// doc comment: `Cx` and `Cz` produce bit-for-bit identical pulses
+    /// in this crate's calibration model, so getting this dispatch
+    /// wrong for a given backend would silently apply the wrong
+    /// two-qubit gate during `execute` -- exactly the kind of error
+    /// this test would catch, since a wrong gate here means Bob's
+    /// qubit ends up in the wrong state and fidelity collapses well
+    /// below 1.0, not just drifts slightly).
+    #[test]
+    fn execute_dispatches_the_correct_native_two_qubit_gate_on_every_backend() {
+        use sirraya_qutub::DensityMatrix;
+
+        fn teleportation_circuit_plus_state() -> Circuit {
+            let mut c = Circuit::new(3);
+            c.push(Gate::H(0)); // |+> on q0
+            c.push(Gate::H(1));
+            c.push(Gate::Cx(1, 2));
+            c.push(Gate::Cx(0, 1));
+            c.push(Gate::H(0));
+            c.num_clbits = 2;
+            c.push(Gate::Measure(0, 0));
+            c.push(Gate::Measure(1, 1));
+            c.push(Gate::If(vec![(1, true)], Box::new(Gate::X(2))));
+            c.push(Gate::If(vec![(0, true)], Box::new(Gate::Z(2))));
+            c
+        }
+
+        let target: DensityMatrix = {
+            let mut reg = QuantumRegister::new(1).unwrap();
+            reg.apply_hadamard(0).unwrap();
+            reg.to_density_matrix().unwrap()
+        };
+
+        for backend in [Backend::TrappedIon, Backend::IbmQ, Backend::Rigetti] {
+            // Backend::Google is deliberately excluded here: pulse.rs
+            // has no `PulseCalibration` constructor for it (only
+            // TrappedIon/IbmQ/Rigetti exist -- see this file's own
+            // `cal()` helper and pulse.rs's own constructors). That's
+            // a real, pre-existing gap in pulse.rs, not something to
+            // paper over with a fabricated calibration here; Google's
+            // `NativeTwoQubitGate::FixedCz` dispatch is still checked
+            // for by Rigetti's own run below (both are `FixedCz`,
+            // just with different published numbers), so this isn't
+            // an entirely uncovered code path, just an entirely
+            // untested *backend*.
+            let cal = match backend.id() {
+                "TrappedIon" => trapped_ion_pulse_calibration(),
+                "IbmQ" => crate::pulse::ibm_heron_r2_pulse_calibration(),
+                "Rigetti" => crate::pulse::rigetti_ankaa3_pulse_calibration(),
+                other => unreachable!("no PulseCalibration case for backend {}", other),
+            };
+
+            let source = teleportation_circuit_plus_state();
+            let bc = backend::lower(&source, backend);
+            let program = compile(&bc, &cal).unwrap();
+
+            for trial in 0..10 {
+                let (reg, _clbits) = execute(&bc, &program, &cal).unwrap();
+                let bob = reg.to_density_matrix().unwrap().partial_trace(&[2]).unwrap();
+                let fidelity = bob.fidelity(&target).unwrap();
+                assert!(
+                    (fidelity - 1.0).abs() < 1e-9,
+                    "backend {:?} trial {}: expected ~100% fidelity, got {} -- likely a wrong \
+                     NativeTwoQubitGate dispatch for this backend",
+                    backend, trial, fidelity
+                );
+            }
+        }
+    }
+
+    /// The real, checkable consequence [`execute_with_readout_noise`]'s
+    /// own doc comment promises: with an extreme (but deterministic,
+    /// so the test doesn't need statistical trial-counting to see the
+    /// effect) readout calibration that always misreports a true "1"
+    /// as "0", the teleportation protocol's corrections get skipped on
+    /// exactly the branches where they were actually needed --
+    /// breaking fidelity -- even though `execute`'s own exact,
+    /// noise-free run of the identical `Program` still reaches ~100%.
+    /// This is the test that actually proves `readout.rs`'s corruption
+    /// model has a real physical effect once wired through `Gate::If`,
+    /// not just that `corrupt_readout` computes the right probability
+    /// in isolation (see `readout.rs`'s own unit tests for that half).
+    #[test]
+    fn readout_noise_can_break_a_correction_decision() {
+        use crate::readout::ReadoutCalibration;
+        use sirraya_qutub::DensityMatrix;
+
+        // p01=0.0, p10=1.0: a true "0" is always reported correctly,
+        // but a true "1" is *always* misreported as "0". Not a
+        // realistic device number -- chosen specifically to make the
+        // consequence deterministic (every trial where the true
+        // outcome is 1 shows the effect, not just "most" trials).
+        let broken_readout = ReadoutCalibration {
+            name: "test: always misreports a true 1 as 0",
+            backend: Backend::TrappedIon,
+            p01: 0.0,
+            p10: 1.0,
+        };
+
+        // Teleport |1> specifically: a deterministic target makes a
+        // wrong final state easy to detect (fidelity clearly < 1.0),
+        // unlike a state where "wrong" and "right" might coincide by
+        // chance for some branches.
+        let mut source = Circuit::new(3);
+        source.push(Gate::X(0));
+        source.push(Gate::H(1));
+        source.push(Gate::Cx(1, 2));
+        source.push(Gate::Cx(0, 1));
+        source.push(Gate::H(0));
+        source.num_clbits = 2;
+        source.push(Gate::Measure(0, 0));
+        source.push(Gate::Measure(1, 1));
+        source.push(Gate::If(vec![(1, true)], Box::new(Gate::X(2))));
+        source.push(Gate::If(vec![(0, true)], Box::new(Gate::Z(2))));
+
+        let bc = backend::lower(&source, Backend::TrappedIon);
+        let cal = trapped_ion_pulse_calibration();
+        let program = compile(&bc, &cal).unwrap();
+
+        let target: DensityMatrix = {
+            let mut reg = QuantumRegister::new(1).unwrap();
+            reg.apply_pauli_x(0).unwrap();
+            reg.to_density_matrix().unwrap()
+        };
+
+        // Sanity check: the exact, noise-free path still reaches
+        // ~100% -- confirms any failure below is readout.rs's doing,
+        // not a pre-existing bug in compile/execute.
+        let (reg_exact, _) = execute(&bc, &program, &cal).unwrap();
+        let bob_exact = reg_exact.to_density_matrix().unwrap().partial_trace(&[2]).unwrap();
+        assert!((bob_exact.fidelity(&target).unwrap() - 1.0).abs() < 1e-9);
+
+        // With p01=0/p10=1, corrupt_readout's outcome doesn't depend
+        // on the sample value at all (see readout.rs's own
+        // certain_error_calibration_always_flips test), so any fixed
+        // sample works here -- what varies trial to trial is the
+        // *true* measurement outcome, which is still genuinely random.
+        let mut saw_broken_fidelity = false;
+        for _ in 0..30 {
+            let (reg_noisy, _clbits) =
+                execute_with_readout_noise(&bc, &program, &cal, &broken_readout, || 0.5).unwrap();
+            let bob_noisy = reg_noisy.to_density_matrix().unwrap().partial_trace(&[2]).unwrap();
+            let fidelity = bob_noisy.fidelity(&target).unwrap();
+            if (fidelity - 1.0).abs() > 1e-6 {
+                saw_broken_fidelity = true;
+            }
+        }
+        // True (m0, m1) is uniform over 4 equally-likely branches; 3
+        // of the 4 need at least one correction this calibration
+        // always suppresses, so the chance all 30 trials land in the
+        // one safe branch is (1/4)^30 -- not a realistic flake.
+        assert!(
+            saw_broken_fidelity,
+            "expected at least one trial where corrupted readout broke teleportation fidelity, \
+             but every trial still reached ~100% -- readout noise isn't reaching Gate::If's \
+             branch decision"
+        );
+    }
+
+    /// The gate-noise counterpart to
+    /// `readout_noise_can_break_a_correction_decision`: proves
+    /// `execute_with_noise`'s `gate_cal` parameter has a real,
+    /// checkable effect on the *quantum* state, not just that
+    /// `noise::sample_depolarizing_error` computes the right
+    /// probability in isolation (see `noise.rs`'s own unit tests for
+    /// that half).
+    ///
+    /// # Why this needs *real* randomness, not a fixed sample
+    /// An earlier version of this test used a single fixed sample
+    /// (`|| 0.5`) for every noise-eligible event, expecting a
+    /// deterministic, guaranteed-probability Pauli kick to obviously
+    /// break fidelity. It didn't -- fidelity came back indistinguishable
+    /// from 1.0. That's not a bug in the noise model; it's a real,
+    /// interesting property of teleportation itself: a *systematic*,
+    /// always-identical Pauli inserted at every gate is exactly the
+    /// kind of error the protocol's own feed-forward correction can
+    /// absorb (teleportation is fundamentally a Pauli-frame-tracking
+    /// protocol -- the same reason gate-teleportation-based
+    /// fault-tolerant constructions work at all), and a Pauli applied
+    /// twice to the same qubit cancels outright (`Y*Y = I`). Real
+    /// depolarizing noise is independent-random *per event*, not a
+    /// systematic insertion, so this test draws real per-event
+    /// randomness (via the `rand` dev-dependency) to actually match
+    /// what the noise model is supposed to represent, and checks
+    /// *average* fidelity across many trials rather than a single
+    /// deterministic run.
+    #[test]
+    fn gate_noise_degrades_average_teleportation_fidelity() {
+        use crate::fidelity::PublishedCalibration;
+        use rand::Rng;
+        use sirraya_qutub::DensityMatrix;
+
+        // p=1.0: every single noise-eligible event draws a real error
+        // (uniformly X, Y, or Z -- never "no error"). Far more
+        // aggressive than any real device's actual error rate,
+        // deliberately, so the average degradation is clearly visible
+        // without needing an enormous trial count.
+        let always_error = PublishedCalibration {
+            name: "test: guaranteed single- and two-qubit error",
+            single_qubit_fidelity: 0.0,
+            two_qubit_fidelity: 0.0,
+        };
+
+        let mut source = Circuit::new(3);
+        source.push(Gate::H(0)); // |+> on q0
+        source.push(Gate::H(1));
+        source.push(Gate::Cx(1, 2));
+        source.push(Gate::Cx(0, 1));
+        source.push(Gate::H(0));
+        source.num_clbits = 2;
+        source.push(Gate::Measure(0, 0));
+        source.push(Gate::Measure(1, 1));
+        source.push(Gate::If(vec![(1, true)], Box::new(Gate::X(2))));
+        source.push(Gate::If(vec![(0, true)], Box::new(Gate::Z(2))));
+
+        let bc = backend::lower(&source, Backend::TrappedIon);
+        let cal = trapped_ion_pulse_calibration();
+        let program = compile(&bc, &cal).unwrap();
+
+        let target: DensityMatrix = {
+            let mut reg = QuantumRegister::new(1).unwrap();
+            reg.apply_hadamard(0).unwrap();
+            reg.to_density_matrix().unwrap()
+        };
+
+        // Sanity check: the exact path still reaches ~100% -- confirms
+        // any degradation below is the noise model's doing, not a
+        // pre-existing bug.
+        let (reg_exact, _) = execute(&bc, &program, &cal).unwrap();
+        let bob_exact = reg_exact.to_density_matrix().unwrap().partial_trace(&[2]).unwrap();
+        assert!((bob_exact.fidelity(&target).unwrap() - 1.0).abs() < 1e-9);
+
+        let mut rng = rand::thread_rng();
+        let trials = 50;
+        let mut total_fidelity = 0.0;
+        for _ in 0..trials {
+            let (reg_noisy, _clbits) =
+                execute_with_noise(&bc, &program, &cal, Some(&always_error), None, || {
+                    rng.gen::<f64>()
+                })
+                .unwrap();
+            let bob_noisy = reg_noisy.to_density_matrix().unwrap().partial_trace(&[2]).unwrap();
+            total_fidelity += bob_noisy.fidelity(&target).unwrap();
+        }
+        let avg_fidelity = total_fidelity / trials as f64;
+        assert!(
+            avg_fidelity < 0.9,
+            "expected guaranteed-probability, genuinely random per-gate noise to substantially \
+             degrade average teleportation fidelity across {} trials, got average {}",
+            trials, avg_fidelity
+        );
+    }
+
+    /// Confirms `execute_with_noise` really does combine both sources
+    /// in one call -- readout noise alone (via `execute_with_readout_noise`)
+    /// only ever breaks fidelity on *some* branches (see that test);
+    /// adding guaranteed, genuinely-random gate noise on top (see
+    /// `gate_noise_degrades_average_teleportation_fidelity`'s doc
+    /// comment on why it must be genuinely random, not a fixed sample),
+    /// via the general `execute_with_noise` entry point, must degrade
+    /// average fidelity too, confirming the two parameters aren't
+    /// silently exclusive of each other.
+    #[test]
+    fn execute_with_noise_applies_both_sources_together() {
+        use crate::fidelity::PublishedCalibration;
+        use crate::readout::ReadoutCalibration;
+        use rand::Rng;
+        use sirraya_qutub::DensityMatrix;
+
+        let always_gate_error = PublishedCalibration {
+            name: "test: guaranteed gate error",
+            single_qubit_fidelity: 0.0,
+            two_qubit_fidelity: 0.0,
+        };
+        let never_readout_error = ReadoutCalibration {
+            name: "test: perfect readout",
+            backend: Backend::TrappedIon,
+            p01: 0.0,
+            p10: 0.0,
+        };
+
+        let mut source = Circuit::new(3);
+        source.push(Gate::H(1));
+        source.push(Gate::Cx(1, 2));
+        source.push(Gate::Cx(0, 1));
+        source.push(Gate::H(0));
+        source.num_clbits = 2;
+        source.push(Gate::Measure(0, 0));
+        source.push(Gate::Measure(1, 1));
+        source.push(Gate::If(vec![(1, true)], Box::new(Gate::X(2))));
+        source.push(Gate::If(vec![(0, true)], Box::new(Gate::Z(2))));
+
+        let bc = backend::lower(&source, Backend::TrappedIon);
+        let cal = trapped_ion_pulse_calibration();
+        let program = compile(&bc, &cal).unwrap();
+
+        let target: DensityMatrix = {
+            let reg = QuantumRegister::new(1).unwrap();
+            reg.to_density_matrix().unwrap()
+        };
+
+        let mut rng = rand::thread_rng();
+        let trials = 50;
+        let mut total_fidelity = 0.0;
+        for _ in 0..trials {
+            let (reg_noisy, _clbits) = execute_with_noise(
+                &bc,
+                &program,
+                &cal,
+                Some(&always_gate_error),
+                Some(&never_readout_error),
+                || rng.gen::<f64>(),
+            )
+            .unwrap();
+            let bob_noisy = reg_noisy.to_density_matrix().unwrap().partial_trace(&[2]).unwrap();
+            total_fidelity += bob_noisy.fidelity(&target).unwrap();
+        }
+        let avg_fidelity = total_fidelity / trials as f64;
+        assert!(
+            avg_fidelity < 0.9,
+            "expected the gate-noise component of execute_with_noise to still degrade average \
+             fidelity even with readout noise set to zero, got average {} across {} trials",
+            avg_fidelity, trials
+        );
+    }
+
+    /// The real payoff of multi-condition `Gate::If`: a genuine joint
+    /// (AND) correction that single-bit `If`s can't express on their
+    /// own -- `Circuit::validate` disallows nesting one `If` inside
+    /// another, so "apply X iff m0==1 AND m1==1" has no way to be
+    /// built from two separate single-condition `If`s at all. Checked
+    /// two ways: symbolically, across all four outcome combinations on
+    /// a circuit with *only* Measure+If (no other real gates, so the
+    /// only source of a fired Drive pulse is the joint condition
+    /// itself, and `expected_fired`'s conditioned-gates-only ground
+    /// truth is a complete account -- see this test's own history: an
+    /// earlier version added unconditional `X(0)`/`X(1)` prep gates
+    /// into this same structural check and got a real, if unrelated,
+    /// mismatch from those prep gates' own unconditional pulses, which
+    /// `expected_fired` was never meant to account for), and against
+    /// real quantum state (which correctly accounts for every gate,
+    /// prep included) for two concrete, deterministically-prepared
+    /// outcomes.
+    #[test]
+    fn multi_condition_if_expresses_a_genuine_joint_correction() {
+        use sirraya_qutub::DensityMatrix;
+
+        fn joint_correction_circuit(prep0: bool, prep1: bool) -> Circuit {
+            let mut c = Circuit::new(3);
+            if prep0 {
+                c.push(Gate::X(0));
+            }
+            if prep1 {
+                c.push(Gate::X(1));
+            }
+            c.num_clbits = 2;
+            c.push(Gate::Measure(0, 0));
+            c.push(Gate::Measure(1, 1));
+            // No single-condition If, or pair of them, can express
+            // this -- it's a genuine joint condition on one gate.
+            c.push(Gate::If(vec![(0, true), (1, true)], Box::new(Gate::X(2))));
+            c
+        }
+
+        let cal = trapped_ion_pulse_calibration();
+
+        // Structural check: no prep gates, so the only thing that can
+        // fire a real Drive pulse at all is the joint If itself --
+        // q2 fires iff BOTH m0 and m1 are 1, never on "either," which
+        // is exactly what a buggy AND-vs-OR mixup in compile_one's
+        // jump-chaining would get wrong.
+        let source = joint_correction_circuit(false, false);
+        let bc = backend::lower(&source, Backend::TrappedIon);
+        let program = compile(&bc, &cal).unwrap();
+        for m0 in [0u8, 1] {
+            for m1 in [0u8, 1] {
+                let outcomes = [m0, m1];
+                let mut fired = symbolic_run(&program, &outcomes);
+                let mut expected = expected_fired(&bc, &outcomes);
+                fired.sort();
+                expected.sort();
+                let should_fire = m0 == 1 && m1 == 1;
+                assert_eq!(
+                    !expected.is_empty(),
+                    should_fire,
+                    "m0={} m1={}: expected ground-truth firing to require BOTH bits set",
+                    m0, m1
+                );
+                assert_eq!(fired, expected, "m0={} m1={}: Program disagreed with ground truth", m0, m1);
+            }
+        }
+
+        // Physical check: deterministically prepare m0=1, m1=1 (the
+        // one branch where the joint condition holds) and confirm q2
+        // really did get flipped, via real execution -- not just the
+        // symbolic branch trace above. Uses full density-matrix
+        // fidelity, which correctly accounts for every gate in the
+        // circuit (prep gates included), unlike the conditioned-gates-
+        // only `expected_fired` used above.
+        let target_flipped: DensityMatrix = {
+            let mut reg = QuantumRegister::new(1).unwrap();
+            reg.apply_pauli_x(0).unwrap();
+            reg.to_density_matrix().unwrap()
+        };
+        let target_unflipped: DensityMatrix = {
+            let reg = QuantumRegister::new(1).unwrap();
+            reg.to_density_matrix().unwrap()
+        };
+
+        let source_both_true = joint_correction_circuit(true, true);
+        let bc_both_true = backend::lower(&source_both_true, Backend::TrappedIon);
+        let program_both_true = compile(&bc_both_true, &cal).unwrap();
+        let (reg, clbits) = execute(&bc_both_true, &program_both_true, &cal).unwrap();
+        assert_eq!(clbits, vec![1, 1]);
+        let q2 = reg.to_density_matrix().unwrap().partial_trace(&[2]).unwrap();
+        assert!((q2.fidelity(&target_flipped).unwrap() - 1.0).abs() < 1e-9);
+
+        // And the negative case: m0=1, m1=0 -- condition doesn't hold,
+        // q2 must stay unflipped.
+        let source_one_true = joint_correction_circuit(true, false);
+        let bc_one_true = backend::lower(&source_one_true, Backend::TrappedIon);
+        let program_one_true = compile(&bc_one_true, &cal).unwrap();
+        let (reg2, clbits2) = execute(&bc_one_true, &program_one_true, &cal).unwrap();
+        assert_eq!(clbits2, vec![1, 0]);
+        let q2_unflipped = reg2.to_density_matrix().unwrap().partial_trace(&[2]).unwrap();
+        assert!((q2_unflipped.fidelity(&target_unflipped).unwrap() - 1.0).abs() < 1e-9);
+    }
+}

--- a/src/waveform_sim.rs
+++ b/src/waveform_sim.rs
@@ -19,10 +19,6 @@
 //! by `theta / PI`, per `pulse.rs`) is the actual check.
 //!
 //! # Scope this module deliberately does NOT cover
-//! - **Two-qubit gates.** `Cx`/`Cz`/`Rzz` need at minimum a four-level
-//!   (two-qubit) Hilbert space to mean anything physically; this
-//!   module's name says *two-level* on purpose. `PulseCalibration`'s
-//!   `two_qubit`/`rzz` fields are not checked by anything here.
 //! - **DRAG's `beta` (Q-quadrature) term.** DRAG's entire physical
 //!   purpose is suppressing leakage into a qubit's *third* level --
 //!   in a strictly two-level model that third level doesn't exist, so
@@ -38,7 +34,8 @@
 //!   done here.
 //! - **Chained/multi-instruction schedules.** Every [`Play`](PulseInstruction::Play)
 //!   is integrated in isolation, starting fresh from
-//!   [`BlochVector::GROUND`] -- not chained through a real
+//!   [`BlochVector::GROUND`] (or [`TwoQubitZZState::EQUAL_SUPERPOSITION`]
+//!   for the two-qubit case below) -- not chained through a real
 //!   [`crate::pulse::Schedule`], so this says nothing about e.g.
 //!   accumulated phase from a preceding `ShiftPhase`.
 //! - **Detuning, dephasing, relaxation.** The drive is assumed
@@ -58,6 +55,94 @@
 //! checked against it, not tautologically. See
 //! [`RABI_RATE_PER_UNIT_AMPLITUDE_RAD_PER_NS`]'s own doc comment and
 //! this module's tests for how each table holds up.
+//!
+//! # Two-qubit gates: [`integrate_two_qubit_zz`]
+//! `Cx`/`Cz`/`Rzz` genuinely do need at least a four-level (two-qubit)
+//! Hilbert space to check physically, which is why this coverage
+//! didn't exist until now -- and why, even now, it stays a
+//! deliberately simplified, mechanism-agnostic model rather than a
+//! claim to simulate any one vendor's real entangling physics.
+//!
+//! **The model.** This crate's own native two-qubit gate,
+//! `Rzz(theta) = exp(-i*theta/2 * Z⊗Z)`, is the entangling primitive
+//! every backend's `push_two_qubit_zz` ultimately re-expresses (see
+//! `backend/spec.rs`'s doc comment). So the natural two-qubit
+//! counterpart to [`integrate`]'s single-qubit on-resonance X-drive is
+//! a driven `Z⊗Z` interaction in the rotating frame,
+//! `H(t) = (Omega(t)/2) * Z⊗Z`. This is *not* a claim to model any
+//! backend's real physical mechanism -- IBM's cross-resonance drive is
+//! genuinely `~X⊗Z`-shaped and needs an echo sequence to become a clean
+//! `Cx` at all; Rigetti's flux-tunable-coupler `Cz` is an
+//! avoided-level-crossing effect; a trapped-ion `Rzz` is a
+//! Mølmer-Sørensen gate coupling through a shared motional mode. None
+//! of those are captured here, deliberately: each is a real, distinct,
+//! device-specific physical process this crate has no measured
+//! parameters for, and fabricating one would be exactly the kind of
+//! invented-not-cited physics this crate's own conventions elsewhere
+//! refuse to produce. What *is* checked, honestly and specifically, is
+//! narrower and still real: does a calibrated pulse's envelope,
+//! integrated over time, deliver the *entangling angle* this crate's
+//! own gate semantics say it should -- the one thing every backend's
+//! two-qubit calibration table has in common regardless of mechanism.
+//!
+//! **Why `Z⊗Z` needs no genuine ODE integration, unlike the
+//! single-qubit case.** `Z⊗Z` is diagonal, so it commutes with itself
+//! at every instant -- there's no precession the way an X-drive rotates
+//! a Bloch vector through multiple axes. The accumulated phase is
+//! exactly the time-integral of the drive envelope, computable in
+//! closed form. [`integrate_two_qubit_zz`] still runs it through the
+//! same fixed-step RK4 machinery [`integrate`] uses (a real, valid way
+//! to compute that integral, and it keeps both integrators structurally
+//! consistent) -- but unlike the single-qubit case, RK4 isn't *load-
+//! bearing* here the way it is for genuine non-commuting dynamics; a
+//! plain quadrature would give the same answer. Said plainly rather
+//! than dressed up as more dynamically rich than it is.
+//!
+//! **What's tracked, and why.** [`TwoQubitZZState`] tracks only the
+//! `{|00>, |01>}` subspace -- the two-dimensional restriction of the
+//! full four-dimensional two-qubit state that's actually informative
+//! here. `Z⊗Z` never transfers population between basis states (it's
+//! diagonal), so starting anywhere outside an equal superposition of
+//! two *different* `Z⊗Z` eigenvalues would only ever accumulate an
+//! unobservable global phase. `|00>` (eigenvalue `+1`) and `|01>`
+//! (eigenvalue `-1`) straddle the two eigenspaces, so their *relative*
+//! phase directly is the accumulated `Rzz` angle -- see
+//! [`TwoQubitZZState::relative_phase_rad`].
+//!
+//! **The two-qubit Rabi-rate constant.**
+//! [`TWO_QUBIT_RABI_RATE_PER_UNIT_AMPLITUDE_RAD_PER_NS`] is derived the
+//! same way [`RABI_RATE_PER_UNIT_AMPLITUDE_RAD_PER_NS`] was, from one
+//! reference table rather than fit per backend -- but
+//! [`crate::pulse::trapped_ion_pulse_calibration`]'s `rzz` table is the
+//! reference here, not IBM's, because it's the one calibration in this
+//! crate that's actually continuously parameterized by a `pi_amplitude`
+//! for this specific gate (`IbmQ`/`Rigetti`'s `two_qubit` tables are
+//! fixed-amplitude, with no analogous "achieves theta" parameterization
+//! to derive a rate from). `IbmQ`'s and `Rigetti`'s fixed `two_qubit`
+//! pulses are then genuinely checked against this same constant --
+//! against the standard maximally-entangling target angle
+//! `theta = PI/2` (the `Rzz` component of a `Cz`, per this crate's own
+//! `native::decompose_cp` identity: `Cz == Rz(pi/2).Rz(pi/2).Rzz(-pi/2)`
+//! up to global phase -- so `|theta| = PI/2` is this crate's *own*,
+//! already-relied-upon definition of what a maximally-entangling `Cz`/
+//! `Cx` pulse should deliver, not a target invented for this check).
+//! **The real finding**: both come back at well under 1% of that
+//! target -- see this module's own tests. This isn't a bug in
+//! `emit.rs`/`backend.rs`/`sequencer.rs`'s actual gate execution
+//! (verified separately, exactly, by `sequencer::execute`'s own
+//! amplitude-inversion tests) -- it's a real, checked property of
+//! `pulse.rs`'s illustrative `two_qubit` tables, whose durations
+//! (hundreds of ns, typical of real superconducting CR/CZ gates) are
+//! roughly 300-500x shorter than `TrappedIon`'s `rzz` table (100
+//! microseconds, typical of a real trapped-ion Mølmer-Sørensen gate) --
+//! applying one universal rate constant across gate-duration regimes
+//! that differ by that much, by design (see the constant's own doc
+//! comment on why it isn't fit per backend), was always going to expose
+//! *some* real mismatch. That the two-qubit case shows a much larger
+//! one than the single-qubit case (where Rigetti's `rot` table only
+//! "weakly fails," per this module's existing tests) is itself the
+//! honest, checked result -- not something to silently patch by
+//! loosening the constant or rewriting `pulse.rs`'s tables to fit.
 
 use crate::pulse::{Envelope, PulseInstruction};
 
@@ -191,6 +276,133 @@ pub fn rotation_angle_rad(v: BlochVector) -> f64 {
     v.z.clamp(-1.0, 1.0).acos()
 }
 
+/// A two-qubit state restricted to the `{|00>, |01>}` subspace, as two
+/// complex amplitudes -- everything [`integrate_two_qubit_zz`] needs.
+/// See this module's doc comment (under "What's tracked, and why") for
+/// why this subspace, specifically, is the informative one for a
+/// driven `Z⊗Z` interaction.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct TwoQubitZZState {
+    /// `(re, im)` amplitude of `|00>`.
+    pub c00: (f64, f64),
+    /// `(re, im)` amplitude of `|01>`.
+    pub c01: (f64, f64),
+}
+
+impl TwoQubitZZState {
+    /// The starting state every [`integrate_two_qubit_zz`] call begins
+    /// from: `(|00> + |01>) / sqrt(2)`, an equal superposition
+    /// straddling `Z⊗Z`'s two eigenspaces.
+    pub const EQUAL_SUPERPOSITION: TwoQubitZZState = TwoQubitZZState {
+        c00: (std::f64::consts::FRAC_1_SQRT_2, 0.0),
+        c01: (std::f64::consts::FRAC_1_SQRT_2, 0.0),
+    };
+
+    /// Should stay `1.0` (up to numerical-integration error) for any
+    /// state reachable by the lossless, unitary evolution
+    /// [`integrate_two_qubit_zz`] implements -- same role as
+    /// [`BlochVector::norm`] one level down.
+    pub fn norm(&self) -> f64 {
+        (self.c00.0 * self.c00.0
+            + self.c00.1 * self.c00.1
+            + self.c01.0 * self.c01.0
+            + self.c01.1 * self.c01.1)
+            .sqrt()
+    }
+
+    /// The relative phase between the `|01>` and `|00>` components --
+    /// `arg(c01) - arg(c00)` -- which is exactly the `Rzz` angle a
+    /// driven `Z⊗Z` Hamiltonian has accumulated so far, matching this
+    /// crate's own sign convention (`Rzz(theta)|01> = e^{i theta/2}|01>`,
+    /// `Rzz(theta)|00> = e^{-i theta/2}|00>`, so the difference is
+    /// exactly `theta`). Not clamped/wrapped to any particular range --
+    /// `atan2` already returns a value in `(-PI, PI]`, and this module
+    /// only ever checks it against angles that comfortably fit there.
+    pub fn relative_phase_rad(&self) -> f64 {
+        self.c01.1.atan2(self.c01.0) - self.c00.1.atan2(self.c00.0)
+    }
+}
+
+fn add_zz(a: TwoQubitZZState, b: TwoQubitZZState) -> TwoQubitZZState {
+    TwoQubitZZState {
+        c00: (a.c00.0 + b.c00.0, a.c00.1 + b.c00.1),
+        c01: (a.c01.0 + b.c01.0, a.c01.1 + b.c01.1),
+    }
+}
+
+fn scale_zz(a: TwoQubitZZState, s: f64) -> TwoQubitZZState {
+    TwoQubitZZState { c00: (a.c00.0 * s, a.c00.1 * s), c01: (a.c01.0 * s, a.c01.1 * s) }
+}
+
+/// Converts a two-qubit `Play` instruction's dimensionless `amplitude`
+/// into a physical `Z⊗Z`-interaction rate, in rad/ns, at the
+/// envelope's peak -- the two-qubit counterpart to
+/// [`RABI_RATE_PER_UNIT_AMPLITUDE_RAD_PER_NS`]. Derived by requiring
+/// [`crate::pulse::trapped_ion_pulse_calibration`]'s `rzz` table's
+/// calibrated `Rzz(a, b, PI)` pulse to integrate to *exactly* a `PI`
+/// `Z⊗Z`-rotation under this module's model:
+/// `rate = PI / (pi_amplitude * integral_of_the_gaussian_square_shape)`.
+/// See this module's doc comment (under "The two-qubit Rabi-rate
+/// constant") for why `TrappedIon`'s table is the reference here
+/// (not IBM's, unlike the single-qubit constant) and what the real,
+/// checked result is for the other two backends' fixed `two_qubit`
+/// tables.
+pub const TWO_QUBIT_RABI_RATE_PER_UNIT_AMPLITUDE_RAD_PER_NS: f64 = 6.832_305_92e-5;
+
+/// Integrates a single two-qubit [`PulseInstruction::Play`] against
+/// the driven `Z⊗Z` model this module's doc comment describes
+/// (under "Two-qubit gates"), using fixed-step RK4, starting from
+/// [`TwoQubitZZState::EQUAL_SUPERPOSITION`]. Returns `Err` for
+/// [`PulseInstruction::ShiftPhase`], for the same reason [`integrate`]
+/// does -- nothing to integrate for a zero-duration virtual update.
+pub fn integrate_two_qubit_zz(instr: &PulseInstruction) -> Result<TwoQubitZZState, String> {
+    let (duration_ns, envelope, amplitude) = match *instr {
+        PulseInstruction::Play { duration_ns, envelope, amplitude, .. } => {
+            (duration_ns, envelope, amplitude)
+        }
+        PulseInstruction::ShiftPhase { .. } => {
+            return Err(
+                "ShiftPhase is a zero-duration virtual phase update, not a physical pulse \
+                 -- nothing to integrate (see pulse.rs's doc comment on virtual-Z)"
+                    .to_string(),
+            );
+        }
+    };
+
+    const STEPS: usize = 2000;
+    let dt = duration_ns / STEPS as f64;
+
+    // d(c00)/dt = -i*(Omega/2)*(+1)*c00, d(c01)/dt = -i*(Omega/2)*(-1)*c01
+    // -- the opposite sign is exactly Z⊗Z's opposite eigenvalue on
+    // |00> vs |01> (see this module's doc comment on why these two
+    // basis states specifically).
+    let deriv = |s: TwoQubitZZState, t_ns: f64| -> TwoQubitZZState {
+        let omega = TWO_QUBIT_RABI_RATE_PER_UNIT_AMPLITUDE_RAD_PER_NS
+            * amplitude
+            * envelope_shape(&envelope, t_ns, duration_ns);
+        let half = omega / 2.0;
+        TwoQubitZZState {
+            c00: (half * s.c00.1, -half * s.c00.0),
+            c01: (-half * s.c01.1, half * s.c01.0),
+        }
+    };
+
+    let mut s = TwoQubitZZState::EQUAL_SUPERPOSITION;
+    let mut t = 0.0;
+    for _ in 0..STEPS {
+        let k1 = deriv(s, t);
+        let k2 = deriv(add_zz(s, scale_zz(k1, dt / 2.0)), t + dt / 2.0);
+        let k3 = deriv(add_zz(s, scale_zz(k2, dt / 2.0)), t + dt / 2.0);
+        let k4 = deriv(add_zz(s, scale_zz(k3, dt)), t + dt);
+        s = add_zz(
+            s,
+            scale_zz(add_zz(add_zz(k1, scale_zz(k2, 2.0)), add_zz(scale_zz(k3, 2.0), k4)), dt / 6.0),
+        );
+        t += dt;
+    }
+    Ok(s)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -302,5 +514,130 @@ mod tests {
             angle_rad: 0.3,
         };
         assert!(integrate(&instr).is_err());
+    }
+
+    fn play_for_rzz(cal: &crate::pulse::TwoQubitContinuousPulseCalibration, theta: f64) -> PulseInstruction {
+        PulseInstruction::Play {
+            channel: Channel::Control(0, 1),
+            start_time_ns: 0.0,
+            duration_ns: cal.duration_ns,
+            envelope: Envelope::GaussianSquare { sigma_ns: cal.sigma_ns, risefall_ns: cal.risefall_ns },
+            amplitude: cal.pi_amplitude * theta / PI,
+        }
+    }
+
+    fn play_for_two_qubit(cal: &crate::pulse::TwoQubitPulseCalibration) -> PulseInstruction {
+        PulseInstruction::Play {
+            channel: Channel::Control(0, 1),
+            start_time_ns: 0.0,
+            duration_ns: cal.duration_ns,
+            envelope: Envelope::GaussianSquare { sigma_ns: cal.sigma_ns, risefall_ns: cal.risefall_ns },
+            amplitude: cal.amplitude,
+        }
+    }
+
+    #[test]
+    fn trapped_ion_rzz_pi_pulse_achieves_a_pi_zz_rotation() {
+        // TrappedIon's rzz table is this module's two-qubit reference
+        // point -- see TWO_QUBIT_RABI_RATE_PER_UNIT_AMPLITUDE_RAD_PER_NS's
+        // own doc comment.
+        let cal = trapped_ion_pulse_calibration();
+        let s = integrate_two_qubit_zz(&play_for_rzz(&cal.rzz.unwrap(), PI)).unwrap();
+        let theta = s.relative_phase_rad();
+        assert!((theta - PI).abs() < 0.01, "expected ~pi, got {theta}");
+    }
+
+    #[test]
+    fn trapped_ion_rzz_half_pi_pulse_achieves_roughly_half_the_zz_rotation() {
+        let cal = trapped_ion_pulse_calibration();
+        let s = integrate_two_qubit_zz(&play_for_rzz(&cal.rzz.unwrap(), PI / 2.0)).unwrap();
+        let theta = s.relative_phase_rad();
+        assert!((theta - PI / 2.0).abs() < 0.01, "expected ~pi/2, got {theta}");
+    }
+
+    #[test]
+    fn zero_amplitude_two_qubit_pulse_achieves_no_zz_rotation() {
+        let cal = trapped_ion_pulse_calibration();
+        let s = integrate_two_qubit_zz(&play_for_rzz(&cal.rzz.unwrap(), 0.0)).unwrap();
+        assert!(
+            s.relative_phase_rad().abs() < 1e-6,
+            "no drive should leave the relative phase at ~0: {s:?}"
+        );
+    }
+
+    #[test]
+    fn two_qubit_integration_preserves_state_norm() {
+        // Same role as integration_preserves_bloch_vector_norm one
+        // level down: unitary evolution must keep the state normalized
+        // -- a check on the integrator's own numerical accuracy,
+        // independent of any calibration table.
+        let cal = trapped_ion_pulse_calibration();
+        let s = integrate_two_qubit_zz(&play_for_rzz(&cal.rzz.unwrap(), PI)).unwrap();
+        assert!((s.norm() - 1.0).abs() < 1e-6, "RK4 drift too large: |s| = {}", s.norm());
+    }
+
+    #[test]
+    fn rzz_relative_phase_scales_linearly_with_theta() {
+        let cal = trapped_ion_pulse_calibration();
+        for &frac in &[0.0, 0.25, 0.5, 0.75, 1.0] {
+            let theta_in = PI * frac;
+            let s = integrate_two_qubit_zz(&play_for_rzz(&cal.rzz.unwrap(), theta_in)).unwrap();
+            let theta_out = s.relative_phase_rad();
+            assert!(
+                (theta_out - theta_in).abs() < 0.01,
+                "at theta={theta_in}, expected achieved angle ~{theta_in}, got {theta_out}"
+            );
+        }
+    }
+
+    #[test]
+    fn shift_phase_is_not_integrable_for_two_qubit_zz_either() {
+        let instr = PulseInstruction::ShiftPhase {
+            channel: Channel::Drive(0),
+            start_time_ns: 0.0,
+            angle_rad: 0.3,
+        };
+        assert!(integrate_two_qubit_zz(&instr).is_err());
+    }
+
+    #[test]
+    fn ibm_and_rigetti_fixed_two_qubit_pulses_fall_far_short_of_the_maximally_entangling_target() {
+        // The real, checked finding this module's doc comment
+        // documents in detail (under "The two-qubit Rabi-rate
+        // constant"): neither IbmQ's nor Rigetti's illustrative,
+        // fixed-amplitude `two_qubit` table comes anywhere close to
+        // the PI/2 maximally-entangling Z⊗Z angle this crate's own
+        // native::decompose_cp identity defines a Cz/Cx pulse as
+        // needing -- both land under 1% of it, a direct, expected
+        // consequence of applying TrappedIon's Mølmer-Sørensen-
+        // timescale (100 microsecond) reference constant to gates
+        // roughly 300-500x shorter, not a bug in this module or in
+        // this crate's actual gate execution (verified separately,
+        // exactly, by sequencer::execute's own tests). A loose upper
+        // bound (10%) rather than a tight one, deliberately: the point
+        // is recording the real magnitude, not asserting a precise
+        // number that would need updating every time pulse.rs's
+        // illustrative tables change.
+        let target = PI / 2.0;
+
+        let ibm_cal = ibm_heron_r2_pulse_calibration();
+        let ibm_s = integrate_two_qubit_zz(&play_for_two_qubit(&ibm_cal.two_qubit)).unwrap();
+        let ibm_theta = ibm_s.relative_phase_rad().abs();
+        assert!(
+            ibm_theta / target < 0.10,
+            "IbmQ's two_qubit pulse achieved {:.6} rad, {:.2}% of the PI/2 target -- expected \
+             well under 10% (see this test's own doc comment on why)",
+            ibm_theta, 100.0 * ibm_theta / target
+        );
+
+        let rigetti_cal = rigetti_ankaa3_pulse_calibration();
+        let rigetti_s = integrate_two_qubit_zz(&play_for_two_qubit(&rigetti_cal.two_qubit)).unwrap();
+        let rigetti_theta = rigetti_s.relative_phase_rad().abs();
+        assert!(
+            rigetti_theta / target < 0.10,
+            "Rigetti's two_qubit pulse achieved {:.6} rad, {:.2}% of the PI/2 target -- expected \
+             well under 10% (see this test's own doc comment on why)",
+            rigetti_theta, 100.0 * rigetti_theta / target
+        );
     }
 }


### PR DESCRIPTION
## Add classical control, real-time execution, and hardware-realistic noise modeling

### Summary
Adds a complete classical-control and execution stack to the compiler, closing the gap where `quantum_teleportation.rs` used to bypass the IR entirely and call the simulator directly. The circuit can now express real classical feedback, compile it to a branching low-level program, execute that program against real quantum state, and model the noise sources (gate error, readout error) that actually matter once this runs on real hardware.

### What changed

**Classical control in the IR**
- `Gate::If(Vec<(usize, bool)>, Box<Gate>)` — conditional gate application on one or more classical bits, ANDed together (not just single-bit conditions). Threaded through decomposition, backend lowering, routing, optimization, diagrams, and QASM round-trip (a documented, non-standard `if (c[i]==v && ...) <stmt>;` extension).

**Real-time execution layer (`sequencer.rs`, new)**
- `Program`/`SeqInstr` — a branching instruction set (`Play`, `MeasureInto`, `JumpIfEqual`, `Jump`, `Halt`) below the existing static `pulse::Schedule`.
- `compile()` lowers a `BackendCircuit` into `Program`, turning `Gate::If` into real conditional jumps (one `JumpIfEqual` per condition for multi-bit ANDs).
- `execute()` runs `Program` against a real `QuantumRegister` — genuine measurement collapse feeding genuine branching, not a simulated stand-in.
- `HardwareTarget` trait — the extension point for a real control-electronics backend (Quantum Machines, Zurich Instruments, etc.), intentionally unimplemented until a real vendor spec is in hand.
- New `BackendSpec::native_two_qubit_gate()` resolves a real ambiguity: `Cx`/`Cz` produce identical pulses in this crate's calibration model, so inverting a pulse back to its gate needed backend-level disambiguation.

**Noise modeling**
- `readout.rs` (new) — real, cited SPAM/readout-error calibrations for all four backends (Quantinuum Helios, IBM Heron r2, Rigetti Ankaa-3, Google Willow), including a genuine asymmetric confusion matrix for Rigetti.
- `noise.rs` (new) — real per-gate depolarizing noise sampled from `fidelity.rs`'s existing cited error rates (previously hand-rolled separately in every noisy example).
- `execute_with_noise()` unifies both into one entry point.

**Two-qubit pulse verification (`waveform_sim.rs`)**
- Extends single-qubit-only pulse verification to `Cx`/`Cz`/`Rzz`, via a driven `Z⊗Z` model. Explicitly documented as mechanism-agnostic (not a claim to simulate cross-resonance, flux-tunable couplers, or Mølmer-Sørensen physics).

### What this enables now
- Circuits with real mid-circuit measurement and feedback (teleportation, QEC-style corrections) compile and execute correctly end to end, at both the gate level and the pulse/sequencer level.
- Joint corrections that depend on more than one classical bit at once are expressible for the first time.
- Noisy simulation now uses one shared, cited noise model instead of four different hand-rolled ones scattered across examples.
- The `sequencer`/`HardwareTarget` layer is the concrete integration point for real control electronics once hardware access is available — the remaining work is one vendor-specific implementation, not new architecture.

### Testing
300 tests (up from 253 at the start of this work), including exhaustive branch-structure checks, real quantum-state fidelity checks (teleportation via `sequencer::execute`), and physical calibration checks against real published hardware numbers. All verified against the actual `sirraya-qutub` dependency, not mocked.