### PR TITLE
Add quantum error correction: qec module (3-qubit bit-flip and phase-…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,19 @@
 //! `sequencer::execute_with_noise` needed the same thing in the
 //! library itself, combined with [`readout`] noise in one place.
 //!
+//! [`qec`] is where the classical-control stack above (`Gate::If`,
+//! `sequencer::execute`, `readout`/`noise`) actually gets used for what
+//! it was ultimately for: real quantum error correction.
+//! [`qec::StabilizerCode`] is the extension point (one trait, one file
+//! per code, mirroring [`backend::BackendSpec`]'s own pattern) for
+//! encode/syndrome-extract/`Gate::If`-conditioned-correct/decode. Two
+//! real, textbook-standard codes ship today
+//! ([`qec::bit_flip::ThreeQubitBitFlipCode`],
+//! [`qec::phase_flip::ThreeQubitPhaseFlipCode`]) -- see that module's
+//! own doc comment for exactly what's covered and, honestly, what a
+//! real next code (anything needing an actual external decoding
+//! algorithm, not a static branch table) would still require.
+//!
 //! [`resource_estimate`] is a separate, additive concern from
 //! everything above: it never touches `sirraya_qutub` at all (it's
 //! pure counting over an [`ir::Circuit`], via [`native::decompose`] +
@@ -122,6 +135,7 @@ pub mod noise;
 pub mod optimize;
 pub mod pulse;
 pub mod qasm;
+pub mod qec;
 pub mod readout;
 pub mod resource_estimate;
 pub mod route;
@@ -144,6 +158,7 @@ pub use pulse::{
 pub use sequencer::{compile as compile_sequencer, execute as execute_sequencer, HardwareTarget, Program, SeqInstr};
 pub use readout::{corrupt_readout, ReadoutCalibration};
 pub use noise::{apply_pauli_error, sample_depolarizing_error, PauliError};
+pub use qec::{bit_flip::ThreeQubitBitFlipCode, phase_flip::ThreeQubitPhaseFlipCode, StabilizerCode};
 pub use fidelity::{estimate_circuit_fidelity, PublishedCalibration};
 pub use route::{route, route_lookahead, route_sabre, route_best, route_best_no_restore, route_qft, restoration_swap_count};
 pub use ibm_export::{to_ibm_qasm, lower_ibm_native, validate_cx_native_basis, IbmInstr};

--- a/src/qec/bit_flip.rs
+++ b/src/qec/bit_flip.rs
@@ -1,0 +1,118 @@
+//! The three-qubit bit-flip code: corrects a single `X` (bit-flip)
+//! error on any one of its three physical qubits. Shor, *Phys. Rev. A*
+//! 52, R2493 (1995); Nielsen & Chuang, *Quantum Computation and
+//! Quantum Information*, Section 10.1.
+//!
+//! # The code
+//! Logical basis states `|0>_L = |000>`, `|1>_L = |111>` -- an
+//! arbitrary logical state `a|0>_L + b|1>_L` is prepared from
+//! `a|0> + b|1>` on `data_qubits[0]` via `Cx(0,1) . Cx(0,2)`.
+//!
+//! Stabilizer generators: `Z0 Z1` and `Z1 Z2` (0-indexed;
+//! `Z1 Z2`/`Z2 Z3` in Nielsen & Chuang's 1-indexed notation). Both
+//! stabilize the codespace (`+1` eigenvalue on both `|000>` and
+//! `|111>`), and together they distinguish which single qubit (if any)
+//! a bit-flip error landed on -- see [`ThreeQubitBitFlipCode::correct`]'s
+//! doc comment for the exact syndrome table this implies.
+//!
+//! # What this code does *not* correct
+//! A `Z` (phase-flip) error -- see [`crate::qec::phase_flip`] for the
+//! dual code that handles it -- or a simultaneous error on more than
+//! one qubit. Precisely: a *single* physical `Z` error on any one
+//! data qubit is mathematically identical to this code's own logical
+//! `Z_L` operator (`Zi|000> = |000>`, `Zi|111> = -|111>`, exactly the
+//! action a logical `Z` should have), so it passes through completely
+//! undetected -- not "corrupted," but indistinguishable from a
+//! deliberate logical gate. Two simultaneous `X` errors similarly
+//! aren't detected as *two* errors; they produce the same syndrome as
+//! some other single-qubit `X` error, so the decoder's "correction"
+//! combines with the real errors into a net logical `X_L` flip
+//! (`X_L = X0 X1 X2`, since flipping every data qubit maps `|000>` to
+//! `|111>` and back). See this module's own tests for both, checked
+//! precisely against the real simulator rather than just asserted.
+
+use crate::ir::{Circuit, Gate};
+use crate::qec::StabilizerCode;
+
+pub struct ThreeQubitBitFlipCode;
+
+impl StabilizerCode for ThreeQubitBitFlipCode {
+    fn id(&self) -> &'static str {
+        "ThreeQubitBitFlip"
+    }
+
+    fn num_data_qubits(&self) -> usize {
+        3
+    }
+
+    fn num_syndrome_bits(&self) -> usize {
+        2
+    }
+
+    fn encode(&self, circuit: &mut Circuit, data_qubits: &[usize]) {
+        assert_eq!(data_qubits.len(), 3, "ThreeQubitBitFlipCode needs exactly 3 data qubits");
+        let (q0, q1, q2) = (data_qubits[0], data_qubits[1], data_qubits[2]);
+        circuit.push(Gate::Cx(q0, q1)).push(Gate::Cx(q0, q2));
+    }
+
+    /// Measures `Z0 Z1` into `syndrome_clbits[0]` and `Z1 Z2` into
+    /// `syndrome_clbits[1]`, via the standard `Z`-type stabilizer
+    /// circuit: each ancilla starts in `|0>`, is the *target* of
+    /// `Cx` from each data qubit the stabilizer touches (parity onto
+    /// the ancilla, no Hadamards needed since `Z⊗Z` is already diagonal
+    /// in the computational basis both the ancilla and data qubits
+    /// start in), then measured directly.
+    fn extract_syndrome(
+        &self,
+        circuit: &mut Circuit,
+        data_qubits: &[usize],
+        ancilla_qubits: &[usize],
+        syndrome_clbits: &[usize],
+    ) {
+        assert_eq!(data_qubits.len(), 3, "ThreeQubitBitFlipCode needs exactly 3 data qubits");
+        assert_eq!(ancilla_qubits.len(), 2, "ThreeQubitBitFlipCode needs exactly 2 ancillas");
+        assert_eq!(syndrome_clbits.len(), 2, "ThreeQubitBitFlipCode needs exactly 2 syndrome bits");
+        let (q0, q1, q2) = (data_qubits[0], data_qubits[1], data_qubits[2]);
+        let (a0, a1) = (ancilla_qubits[0], ancilla_qubits[1]);
+        // Z0 Z1 -> syndrome_clbits[0]
+        circuit.push(Gate::Cx(q0, a0)).push(Gate::Cx(q1, a0));
+        // Z1 Z2 -> syndrome_clbits[1]
+        circuit.push(Gate::Cx(q1, a1)).push(Gate::Cx(q2, a1));
+        circuit
+            .push(Gate::Measure(a0, syndrome_clbits[0]))
+            .push(Gate::Measure(a1, syndrome_clbits[1]));
+    }
+
+    /// The syndrome table this code's two stabilizers imply: `Z0 Z1`
+    /// anticommutes with (and so flips the sign measured by) an `X`
+    /// error on `q0` or `q1`; `Z1 Z2` anticommutes with an `X` error on
+    /// `q1` or `q2`. So a single `X` error on:
+    /// - `q0` flips only the first syndrome bit: `(1, 0)`.
+    /// - `q1` flips both (it's in both stabilizers): `(1, 1)`.
+    /// - `q2` flips only the second: `(0, 1)`.
+    /// - no error: `(0, 0)`, no correction.
+    ///
+    /// Each of the three nontrivial cases is exactly one
+    /// [`crate::ir::Gate::If`] with a two-condition AND over
+    /// `syndrome_clbits` -- the real thing this code exists to
+    /// demonstrate (see `qec/mod.rs`'s own doc comment).
+    fn correct(&self, circuit: &mut Circuit, data_qubits: &[usize], syndrome_clbits: &[usize]) {
+        assert_eq!(data_qubits.len(), 3, "ThreeQubitBitFlipCode needs exactly 3 data qubits");
+        assert_eq!(syndrome_clbits.len(), 2, "ThreeQubitBitFlipCode needs exactly 2 syndrome bits");
+        let (q0, q1, q2) = (data_qubits[0], data_qubits[1], data_qubits[2]);
+        let (s0, s1) = (syndrome_clbits[0], syndrome_clbits[1]);
+        circuit.push(Gate::If(vec![(s0, true), (s1, false)], Box::new(Gate::X(q0))));
+        circuit.push(Gate::If(vec![(s0, true), (s1, true)], Box::new(Gate::X(q1))));
+        circuit.push(Gate::If(vec![(s0, false), (s1, true)], Box::new(Gate::X(q2))));
+    }
+
+    /// The exact inverse of [`encode`](Self::encode) -- `Cx(0,1)` and
+    /// `Cx(0,2)` are each their own inverse, and the two commute (same
+    /// control, different targets), so re-applying them in either
+    /// order undoes the encoding.
+    fn decode(&self, circuit: &mut Circuit, data_qubits: &[usize]) {
+        assert_eq!(data_qubits.len(), 3, "ThreeQubitBitFlipCode needs exactly 3 data qubits");
+        let (q0, q1, q2) = (data_qubits[0], data_qubits[1], data_qubits[2]);
+        circuit.push(Gate::Cx(q0, q2)).push(Gate::Cx(q0, q1));
+    }
+}

--- a/src/qec/mod.rs
+++ b/src/qec/mod.rs
@@ -1,0 +1,383 @@
+//! The open extension point for adding a quantum error-correcting code
+//! to this crate -- deliberately mirrors [`crate::backend::BackendSpec`]'s
+//! own one-trait-per-implementation pattern (see that module's doc
+//! comment for the rationale, which applies here unchanged): implement
+//! [`StabilizerCode`] once, in its own file under `src/qec/`, to add a
+//! new code. [`bit_flip::ThreeQubitBitFlipCode`] and
+//! [`phase_flip::ThreeQubitPhaseFlipCode`] are the two codes shipped
+//! today.
+//!
+//! # Why these two codes, and not more, today
+//! Both are the standard three-qubit repetition codes from the
+//! original QEC literature -- Shor, "Scheme for reducing decoherence
+//! in quantum computer memory," *Phys. Rev. A* 52, R2493 (1995), and
+//! the modern textbook treatment in Nielsen & Chuang, *Quantum
+//! Computation and Quantum Information*, Section 10.1 ("Three qubit
+//! bit flip code") and 10.1.2 ("Three qubit phase flip code"). Their
+//! syndrome decoding is exactly a lookup table over two classical
+//! bits, which is precisely what [`crate::ir::Gate::If`]'s multi-bit
+//! AND conditions exist to express -- see [`StabilizerCode::correct`]'s
+//! own doc comment on each code's file for the exact table.
+//!
+//! What's deliberately *not* here yet: any code whose decoder isn't a
+//! small, explicit lookup table. A real surface code (or any code at
+//! meaningful distance) needs a genuine external decoding algorithm --
+//! minimum-weight perfect matching, union-find, or a trained neural
+//! decoder -- that runs real classical computation on the syndrome,
+//! not a static branch table `Gate::If`/`SeqInstr::JumpIfEqual` can
+//! express. Building a fake version of that (a lookup table dressed up
+//! to look like a real decoder) would be exactly the kind of
+//! fabricated-to-look-complete work this crate's conventions elsewhere
+//! refuse to produce -- see `sequencer.rs`'s own doc comment on why no
+//! `HardwareTarget` implementation ships without a real vendor spec to
+//! check it against, for the same reasoning applied here. A real
+//! surface-code (or similar) implementation is genuine, larger,
+//! separate follow-on work: it needs `StabilizerCode` (or a
+//! generalization of it) *plus* a real decoding-algorithm integration
+//! this crate doesn't have yet.
+//!
+//! # Verification methodology
+//! Every claim this module's own tests make ("this code corrects any
+//! single bit-flip error") is checked against the real simulator, the
+//! same standard every other rewrite in this crate is held to (see
+//! `tests/decompositions.rs`, `examples/verify_equivalence.rs`,
+//! `sequencer.rs`'s own tests): prepare an arbitrary logical state,
+//! inject a specific error, run the *real* encode -> syndrome-extract
+//! -> `Gate::If`-conditioned correct -> decode circuit, and compare
+//! the recovered qubit's density matrix against the original
+//! preparation's, via `DensityMatrix::fidelity` -- not asserted
+//! algebraically.
+
+use crate::ir::Circuit;
+
+pub mod bit_flip;
+pub mod phase_flip;
+
+/// One quantum error-correcting code: how to encode a single logical
+/// qubit into several physical ones, how to extract a syndrome via
+/// ancilla qubits, and how to classically decode that syndrome into a
+/// correction -- see this module's doc comment for the two codes
+/// shipped today and what it would take to add another.
+///
+/// Every method appends gates to an existing `Circuit` (the same
+/// "build onto a caller-supplied circuit" shape
+/// [`crate::backend::BackendSpec::push_two_qubit_zz`] already uses)
+/// rather than returning a new one, so a caller can freely interleave
+/// a code's own gates with anything else in a larger circuit (state
+/// preparation, a deliberately-injected test error, multiple rounds).
+pub trait StabilizerCode: Send + Sync {
+    /// Stable identifier, e.g. `"ThreeQubitBitFlip"`. Same role as
+    /// [`crate::backend::BackendSpec::id`].
+    fn id(&self) -> &'static str;
+
+    /// How many physical data qubits this code uses to encode one
+    /// logical qubit. Every method below that takes a `data_qubits`
+    /// slice requires it to have exactly this length.
+    fn num_data_qubits(&self) -> usize;
+
+    /// How many stabilizer generators this code measures -- equal to
+    /// the number of ancilla qubits [`extract_syndrome`](Self::extract_syndrome)
+    /// needs and the number of classical bits the syndrome occupies.
+    fn num_syndrome_bits(&self) -> usize;
+
+    /// Appends the encoding circuit: `data_qubits[0]` holds the
+    /// logical qubit's state to encode (any single-qubit state a
+    /// caller already prepared there); every other data qubit must
+    /// start in `|0>`. After this, the logical state is spread across
+    /// all of `data_qubits`.
+    fn encode(&self, circuit: &mut Circuit, data_qubits: &[usize]);
+
+    /// Appends syndrome extraction: measures every stabilizer
+    /// generator via `ancilla_qubits` (which must start in `|0>`,
+    /// length [`num_syndrome_bits`](Self::num_syndrome_bits)), writing
+    /// each result into the corresponding entry of `syndrome_clbits`
+    /// (same length). Does not modify `data_qubits`' encoded state --
+    /// a stabilizer measurement's whole point is projecting onto an
+    /// eigenspace without disturbing the encoded logical information.
+    fn extract_syndrome(
+        &self,
+        circuit: &mut Circuit,
+        data_qubits: &[usize],
+        ancilla_qubits: &[usize],
+        syndrome_clbits: &[usize],
+    );
+
+    /// Appends the classically-conditioned correction -- built
+    /// entirely from [`crate::ir::Gate::If`] reading `syndrome_clbits`,
+    /// the real thing this method exists to demonstrate (see this
+    /// module's own doc comment). See each concrete code's own doc
+    /// comment for its exact syndrome-to-correction table.
+    fn correct(&self, circuit: &mut Circuit, data_qubits: &[usize], syndrome_clbits: &[usize]);
+
+    /// Appends the decoding circuit that reverses
+    /// [`encode`](Self::encode), collapsing the logical information
+    /// back onto `data_qubits[0]` alone. Meant for verification (and
+    /// for a caller that wants the logical qubit back for further use)
+    /// -- assumes [`correct`](Self::correct) already fixed any error,
+    /// the same precondition real error-correction always has.
+    fn decode(&self, circuit: &mut Circuit, data_qubits: &[usize]);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::emit;
+    use crate::ir::Gate;
+    use crate::qec::bit_flip::ThreeQubitBitFlipCode;
+    use crate::qec::phase_flip::ThreeQubitPhaseFlipCode;
+    use sirraya_qutub::core::QuantumRegister;
+    use sirraya_qutub::DensityMatrix;
+
+    /// Builds and runs one full QEC round for any [`StabilizerCode`]:
+    /// prepare an arbitrary state on the logical qubit via `prep`,
+    /// encode, optionally inject `injected_error` (a single gate,
+    /// standing in for a physical error on one qubit at one point in
+    /// time), extract syndrome, classically-conditioned correct,
+    /// decode -- then return the recovered qubit's reduced density
+    /// matrix. Generic over `code`, so the exact same harness verifies
+    /// every concrete `StabilizerCode` this crate ships, which is the
+    /// real payoff of the trait being genuinely modular (see
+    /// `qec/mod.rs`'s own doc comment).
+    fn run_one_round(
+        code: &dyn StabilizerCode,
+        prep: impl Fn(&mut Circuit, usize),
+        injected_error: Option<Gate>,
+    ) -> DensityMatrix {
+        let n = code.num_data_qubits();
+        let s = code.num_syndrome_bits();
+        let mut c = Circuit::new(n + s);
+        c.num_clbits = s;
+
+        let data_qubits: Vec<usize> = (0..n).collect();
+        let ancilla_qubits: Vec<usize> = (n..n + s).collect();
+        let syndrome_clbits: Vec<usize> = (0..s).collect();
+
+        prep(&mut c, data_qubits[0]);
+        code.encode(&mut c, &data_qubits);
+        if let Some(g) = injected_error {
+            c.push(g);
+        }
+        code.extract_syndrome(&mut c, &data_qubits, &ancilla_qubits, &syndrome_clbits);
+        code.correct(&mut c, &data_qubits, &syndrome_clbits);
+        code.decode(&mut c, &data_qubits);
+
+        let optimized = crate::ir_optimize::optimize(&c);
+        let native = crate::native::decompose(&optimized);
+        let (reg, _clbits) = emit::run_with_measurement(&native).unwrap();
+        reg.to_density_matrix().unwrap().partial_trace(&[data_qubits[0]]).unwrap()
+    }
+
+    fn plus_state_target() -> DensityMatrix {
+        let mut reg = QuantumRegister::new(1).unwrap();
+        reg.apply_hadamard(0).unwrap();
+        reg.to_density_matrix().unwrap()
+    }
+
+    fn arbitrary_state_prep(c: &mut Circuit, q: usize) {
+        // Ry(0.7) then Rz(1.3) on |0> -- a generic, non-basis-aligned
+        // state, the same style of coverage
+        // `examples/quantum_teleportation.rs` already uses for its own
+        // "arbitrary state" case.
+        c.push(Gate::Rz(q, 1.3));
+        c.push(Gate::Ry(q, 0.7));
+    }
+
+    fn arbitrary_state_target() -> DensityMatrix {
+        let mut reg = QuantumRegister::new(1).unwrap();
+        reg.apply_rz(0, 1.3).unwrap();
+        reg.apply_ry(0, 0.7).unwrap();
+        reg.to_density_matrix().unwrap()
+    }
+
+    #[test]
+    fn bit_flip_code_corrects_any_single_x_error() {
+        let code = ThreeQubitBitFlipCode;
+        for (prep, target) in [
+            (arbitrary_state_prep as fn(&mut Circuit, usize), arbitrary_state_target()),
+            (|c: &mut Circuit, q: usize| { c.push(Gate::H(q)); }, plus_state_target()),
+        ] {
+            for injected in [None, Some(Gate::X(0)), Some(Gate::X(1)), Some(Gate::X(2))] {
+                let recovered = run_one_round(&code, prep, injected.clone());
+                let fidelity = recovered.fidelity(&target).unwrap();
+                assert!(
+                    (fidelity - 1.0).abs() < 1e-9,
+                    "bit-flip code, injected error {:?}: expected ~100% recovery fidelity, got {}",
+                    injected, fidelity
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn phase_flip_code_corrects_any_single_z_error() {
+        let code = ThreeQubitPhaseFlipCode;
+        for (prep, target) in [
+            (arbitrary_state_prep as fn(&mut Circuit, usize), arbitrary_state_target()),
+            (|c: &mut Circuit, q: usize| { c.push(Gate::H(q)); }, plus_state_target()),
+        ] {
+            for injected in [None, Some(Gate::Z(0)), Some(Gate::Z(1)), Some(Gate::Z(2))] {
+                let recovered = run_one_round(&code, prep, injected.clone());
+                let fidelity = recovered.fidelity(&target).unwrap();
+                assert!(
+                    (fidelity - 1.0).abs() < 1e-9,
+                    "phase-flip code, injected error {:?}: expected ~100% recovery fidelity, got {}",
+                    injected, fidelity
+                );
+            }
+        }
+    }
+
+    /// The honest limit, checked *precisely* rather than just claimed
+    /// in prose (see `qec/mod.rs`'s "what this does not correct" doc
+    /// comments): the bit-flip code's stabilizers are `Z`-type, which
+    /// commute with any `Z` error regardless of location, so the
+    /// syndrome always reads `(0,0)` and no correction ever fires. A
+    /// single physical `Z` error is, for this code, mathematically
+    /// identical to its own logical `Z_L` operator (`Zi|000>=|000>`,
+    /// `Zi|111>=-|111>` -- exactly the action a logical `Z` should
+    /// have, for any single `i`) -- so the recovered state should
+    /// match *exactly* what a bare `Z` on the original preparation
+    /// gives, computed independently here, not merely "some
+    /// corruption happened below a threshold."
+    #[test]
+    fn bit_flip_code_does_not_correct_a_z_error_it_is_the_logical_z() {
+        let code = ThreeQubitBitFlipCode;
+        let target = arbitrary_state_target();
+        let recovered = run_one_round(&code, arbitrary_state_prep, Some(Gate::Z(1)));
+
+        let expected_logical_z: DensityMatrix = {
+            let mut reg = QuantumRegister::new(1).unwrap();
+            reg.apply_rz(0, 1.3).unwrap();
+            reg.apply_ry(0, 0.7).unwrap();
+            reg.apply_pauli_z(0).unwrap();
+            reg.to_density_matrix().unwrap()
+        };
+        let expected_fidelity_vs_original = expected_logical_z.fidelity(&target).unwrap();
+        assert!(
+            expected_fidelity_vs_original < 0.99,
+            "test setup: the chosen state's logical-Z fidelity against itself should not be \
+             ~1.0, got {} -- pick a different arbitrary_state_prep angle",
+            expected_fidelity_vs_original
+        );
+
+        let actual_fidelity_vs_logical_z = recovered.fidelity(&expected_logical_z).unwrap();
+        assert!(
+            (actual_fidelity_vs_logical_z - 1.0).abs() < 1e-9,
+            "expected a single Z error on this code to act as exactly the logical Z operator \
+             (fidelity {} against the predicted Z-flipped state, expected ~1.0) -- got fidelity \
+             {} against the original, un-Z'd target instead",
+            actual_fidelity_vs_logical_z,
+            recovered.fidelity(&target).unwrap()
+        );
+    }
+
+    /// The symmetric honest limit for the phase-flip code, stated
+    /// precisely: a *single* physical `X` error isn't merely
+    /// "uncorrected corruption" for this code -- it's mathematically
+    /// identical to the code's own **logical `Z` operator**. The
+    /// phase-flip code is the bit-flip code conjugated by `H` on every
+    /// data qubit (see `qec/phase_flip.rs`'s own doc comment), and the
+    /// bit-flip code's logical `Z_L` is any single physical `Zi`
+    /// (`Zi|000> = |000>`, `Zi|111> = -|111>` -- exactly a logical `Z`
+    /// action); conjugating by `H` turns that single `Zi` into a
+    /// single `Xi` (`H.Z.H = X`). So a lone physical `X` error, for
+    /// this code specifically, is indistinguishable from a *deliberate*
+    /// logical `Z` gate -- not detected, not corrected, because the
+    /// code's `X`-type stabilizers were never going to catch it (an
+    /// earlier version of this test wrongly expected the result to
+    /// match a *bare X* on the original state; the correct prediction,
+    /// confirmed below, is a bare *Z*).
+    #[test]
+    fn phase_flip_code_does_not_correct_an_x_error_it_is_the_logical_z() {
+        let code = ThreeQubitPhaseFlipCode;
+        let target = arbitrary_state_target();
+        let recovered = run_one_round(&code, arbitrary_state_prep, Some(Gate::X(1)));
+
+        let expected_logical_z: DensityMatrix = {
+            let mut reg = QuantumRegister::new(1).unwrap();
+            reg.apply_rz(0, 1.3).unwrap();
+            reg.apply_ry(0, 0.7).unwrap();
+            reg.apply_pauli_z(0).unwrap();
+            reg.to_density_matrix().unwrap()
+        };
+        let expected_fidelity_vs_original = expected_logical_z.fidelity(&target).unwrap();
+        assert!(
+            expected_fidelity_vs_original < 0.99,
+            "test setup: the chosen state's logical-Z fidelity against itself should not be \
+             ~1.0, got {} -- pick a different arbitrary_state_prep angle",
+            expected_fidelity_vs_original
+        );
+
+        let actual_fidelity_vs_logical_z = recovered.fidelity(&expected_logical_z).unwrap();
+        assert!(
+            (actual_fidelity_vs_logical_z - 1.0).abs() < 1e-9,
+            "expected a single X error on this code to act as exactly the logical Z operator \
+             (fidelity {} against the predicted Z-flipped state, expected ~1.0) -- got fidelity \
+             {} against the original, un-Z'd target instead",
+            actual_fidelity_vs_logical_z,
+            recovered.fidelity(&target).unwrap()
+        );
+    }
+
+    /// The other honest limit: distance 3 means *one* error, not two.
+    /// Two simultaneous `X` errors on `q0` and `q1` produce a syndrome
+    /// indistinguishable from a *different* single error -- `X(q0)`
+    /// flips only the first stabilizer, `X(q1)` flips both, so their
+    /// XOR is `(0,1)`, exactly the syndrome a lone `X(q2)` would give.
+    /// The decoder applies `X(q2)` on top of the two real errors,
+    /// leaving a net `X⊗X⊗X` on the three data qubits -- a coherent
+    /// *logical* `X` flip, not incoherent garbage. Checked precisely:
+    /// the recovered state should match exactly what a bare logical
+    /// `X` on the original preparation gives (computed independently),
+    /// not merely "some low fidelity against the original." An earlier
+    /// version of this test used `|+>` as the prepared state and found
+    /// fidelity ~1.0 -- not a bug, but a genuinely blind test vector:
+    /// `X|+> = |+>`, so a logical-X-type miscorrection is invisible to
+    /// it specifically. `arbitrary_state_prep` isn't an `X` eigenstate,
+    /// so it actually reveals the effect.
+    #[test]
+    fn bit_flip_code_miscorrects_two_simultaneous_errors_as_a_logical_x_flip() {
+        let code = ThreeQubitBitFlipCode;
+        let target = arbitrary_state_target();
+
+        let mut c = Circuit::new(5);
+        c.num_clbits = 2;
+        arbitrary_state_prep(&mut c, 0);
+        code.encode(&mut c, &[0, 1, 2]);
+        c.push(Gate::X(0));
+        c.push(Gate::X(1));
+        code.extract_syndrome(&mut c, &[0, 1, 2], &[3, 4], &[0, 1]);
+        code.correct(&mut c, &[0, 1, 2], &[0, 1]);
+        code.decode(&mut c, &[0, 1, 2]);
+
+        let optimized = crate::ir_optimize::optimize(&c);
+        let native = crate::native::decompose(&optimized);
+        let (reg, _clbits) = emit::run_with_measurement(&native).unwrap();
+        let recovered = reg.to_density_matrix().unwrap().partial_trace(&[0]).unwrap();
+
+        let expected_logical_x_flip: DensityMatrix = {
+            let mut reg = QuantumRegister::new(1).unwrap();
+            reg.apply_rz(0, 1.3).unwrap();
+            reg.apply_ry(0, 0.7).unwrap();
+            reg.apply_pauli_x(0).unwrap();
+            reg.to_density_matrix().unwrap()
+        };
+        let expected_fidelity_vs_original = expected_logical_x_flip.fidelity(&target).unwrap();
+        assert!(
+            expected_fidelity_vs_original < 0.99,
+            "test setup: the chosen state's logical-X-flip fidelity against itself should not \
+             be ~1.0, got {} -- pick a different arbitrary_state_prep angle",
+            expected_fidelity_vs_original
+        );
+
+        let actual_fidelity_vs_flip = recovered.fidelity(&expected_logical_x_flip).unwrap();
+        assert!(
+            (actual_fidelity_vs_flip - 1.0).abs() < 1e-9,
+            "expected two simultaneous errors to produce exactly a net logical X flip \
+             (fidelity {} against the predicted flipped state, expected ~1.0) -- got fidelity \
+             {} against the original, unflipped target instead",
+            actual_fidelity_vs_flip,
+            recovered.fidelity(&target).unwrap()
+        );
+    }
+}

--- a/src/qec/phase_flip.rs
+++ b/src/qec/phase_flip.rs
@@ -1,0 +1,137 @@
+//! The three-qubit phase-flip code: corrects a single `Z` (phase-flip)
+//! error on any one of its three physical qubits -- the dual of
+//! [`crate::qec::bit_flip::ThreeQubitBitFlipCode`], using `X`-type
+//! stabilizers instead of `Z`-type. Nielsen & Chuang, *Quantum
+//! Computation and Quantum Information*, Section 10.1.2.
+//!
+//! # The code
+//! Logical basis states `|0>_L = |+++>`, `|1>_L = |--->`: the same
+//! `Cx(0,1) . Cx(0,2)` encoding as the bit-flip code, followed by `H`
+//! on every data qubit (turning `|000>`/`|111>` into `|+++>`/`|--->`).
+//!
+//! Stabilizer generators: `X0 X1` and `X1 X2`. Measuring an `X`-type
+//! stabilizer needs a different ancilla circuit than a `Z`-type one --
+//! see [`ThreeQubitPhaseFlipCode::extract_syndrome`]'s doc comment --
+//! but the resulting syndrome table is structurally identical to the
+//! bit-flip code's (see [`ThreeQubitPhaseFlipCode::correct`]), just
+//! correcting with `Z` instead of `X`.
+//!
+//! # What this code does *not* correct
+//! An `X` (bit-flip) error, or a simultaneous error on more than one
+//! qubit -- symmetric to [`crate::qec::bit_flip`]'s own limits.
+//! Precisely: this code is the bit-flip code conjugated by `H` on
+//! every data qubit, so its logical operators are also conjugated
+//! (`H.Z.H = X`, `H.(X0X1X2).H = Z0Z1Z2`) -- meaning a *single*
+//! physical `X` error on any one data qubit is mathematically
+//! identical to this code's own logical `Z_L` operator, passing
+//! through completely undetected, not "corrupted" so much as
+//! indistinguishable from a deliberate logical gate. See this
+//! module's own tests, checked precisely against the real simulator.
+
+use crate::ir::{Circuit, Gate};
+use crate::qec::StabilizerCode;
+
+pub struct ThreeQubitPhaseFlipCode;
+
+impl StabilizerCode for ThreeQubitPhaseFlipCode {
+    fn id(&self) -> &'static str {
+        "ThreeQubitPhaseFlip"
+    }
+
+    fn num_data_qubits(&self) -> usize {
+        3
+    }
+
+    fn num_syndrome_bits(&self) -> usize {
+        2
+    }
+
+    fn encode(&self, circuit: &mut Circuit, data_qubits: &[usize]) {
+        assert_eq!(data_qubits.len(), 3, "ThreeQubitPhaseFlipCode needs exactly 3 data qubits");
+        let (q0, q1, q2) = (data_qubits[0], data_qubits[1], data_qubits[2]);
+        circuit
+            .push(Gate::Cx(q0, q1))
+            .push(Gate::Cx(q0, q2))
+            .push(Gate::H(q0))
+            .push(Gate::H(q1))
+            .push(Gate::H(q2));
+    }
+
+    /// Measures `X0 X1` into `syndrome_clbits[0]` and `X1 X2` into
+    /// `syndrome_clbits[1]`, via the standard `X`-type stabilizer
+    /// circuit: each ancilla starts in `|0>`, is Hadamard'd into
+    /// `|+>`, *controls* a `Cx` onto each data qubit the stabilizer
+    /// touches (the reverse control/target direction from the
+    /// `Z`-type case, since an `X`-type stabilizer needs the ancilla
+    /// acting in the Hadamard basis), is Hadamard'd back, then
+    /// measured. This is the standard general stabilizer-measurement
+    /// circuit for an `X`-type generator, not something invented for
+    /// this code specifically.
+    fn extract_syndrome(
+        &self,
+        circuit: &mut Circuit,
+        data_qubits: &[usize],
+        ancilla_qubits: &[usize],
+        syndrome_clbits: &[usize],
+    ) {
+        assert_eq!(data_qubits.len(), 3, "ThreeQubitPhaseFlipCode needs exactly 3 data qubits");
+        assert_eq!(ancilla_qubits.len(), 2, "ThreeQubitPhaseFlipCode needs exactly 2 ancillas");
+        assert_eq!(
+            syndrome_clbits.len(),
+            2,
+            "ThreeQubitPhaseFlipCode needs exactly 2 syndrome bits"
+        );
+        let (q0, q1, q2) = (data_qubits[0], data_qubits[1], data_qubits[2]);
+        let (a0, a1) = (ancilla_qubits[0], ancilla_qubits[1]);
+        // X0 X1 -> syndrome_clbits[0]
+        circuit
+            .push(Gate::H(a0))
+            .push(Gate::Cx(a0, q0))
+            .push(Gate::Cx(a0, q1))
+            .push(Gate::H(a0));
+        // X1 X2 -> syndrome_clbits[1]
+        circuit
+            .push(Gate::H(a1))
+            .push(Gate::Cx(a1, q1))
+            .push(Gate::Cx(a1, q2))
+            .push(Gate::H(a1));
+        circuit
+            .push(Gate::Measure(a0, syndrome_clbits[0]))
+            .push(Gate::Measure(a1, syndrome_clbits[1]));
+    }
+
+    /// Structurally identical table to
+    /// [`ThreeQubitBitFlipCode::correct`](crate::qec::bit_flip::ThreeQubitBitFlipCode::correct)'s,
+    /// with `Z` corrections in place of `X`: `X0 X1` anticommutes with
+    /// a `Z` error on `q0` or `q1`; `X1 X2` anticommutes with a `Z`
+    /// error on `q1` or `q2`. `(1,0)` -> `Z(q0)`, `(1,1)` -> `Z(q1)`,
+    /// `(0,1)` -> `Z(q2)`, `(0,0)` -> no correction.
+    fn correct(&self, circuit: &mut Circuit, data_qubits: &[usize], syndrome_clbits: &[usize]) {
+        assert_eq!(data_qubits.len(), 3, "ThreeQubitPhaseFlipCode needs exactly 3 data qubits");
+        assert_eq!(
+            syndrome_clbits.len(),
+            2,
+            "ThreeQubitPhaseFlipCode needs exactly 2 syndrome bits"
+        );
+        let (q0, q1, q2) = (data_qubits[0], data_qubits[1], data_qubits[2]);
+        let (s0, s1) = (syndrome_clbits[0], syndrome_clbits[1]);
+        circuit.push(Gate::If(vec![(s0, true), (s1, false)], Box::new(Gate::Z(q0))));
+        circuit.push(Gate::If(vec![(s0, true), (s1, true)], Box::new(Gate::Z(q1))));
+        circuit.push(Gate::If(vec![(s0, false), (s1, true)], Box::new(Gate::Z(q2))));
+    }
+
+    /// The exact inverse of [`encode`](Self::encode): undo the `H`s
+    /// first, then the same commuting-`Cx`-pair argument
+    /// [`ThreeQubitBitFlipCode::decode`](crate::qec::bit_flip::ThreeQubitBitFlipCode::decode)
+    /// uses.
+    fn decode(&self, circuit: &mut Circuit, data_qubits: &[usize]) {
+        assert_eq!(data_qubits.len(), 3, "ThreeQubitPhaseFlipCode needs exactly 3 data qubits");
+        let (q0, q1, q2) = (data_qubits[0], data_qubits[1], data_qubits[2]);
+        circuit
+            .push(Gate::H(q0))
+            .push(Gate::H(q1))
+            .push(Gate::H(q2))
+            .push(Gate::Cx(q0, q2))
+            .push(Gate::Cx(q0, q1));
+    }
+}


### PR DESCRIPTION

### Summary
Adds real quantum error correction, built on the classical-control stack from previous work — this is the payload `Gate::If`'s multi-bit conditions and `sequencer::execute` were ultimately for. New `qec` module, mirroring `backend::BackendSpec`'s one-trait-per-implementation pattern: implement `StabilizerCode` once, in its own file, to add a code.

### What changed
- **`qec/mod.rs`** — `StabilizerCode` trait: `encode` / `extract_syndrome` / `correct` / `decode`, each appending gates onto a caller-supplied `Circuit`.
- **`qec/bit_flip.rs`** — `ThreeQubitBitFlipCode`. Standard `Z0Z1`/`Z1Z2` stabilizers; syndrome-to-correction decoded via three `Gate::If`s, each a genuine two-bit AND condition.
- **`qec/phase_flip.rs`** — `ThreeQubitPhaseFlipCode`, the dual code (`X0X1`/`X1X2` stabilizers, correcting `Z` instead of `X`).
- Both cite Shor, *Phys. Rev. A* 52, R2493 (1995) and Nielsen & Chuang §10.1.
- `lib.rs`: `pub mod qec;`, re-exports, one doc paragraph. No other file touched.

### Scope, explicit
Only codes whose decoder is a small, static lookup table. A real surface code (or anything at meaningful distance) needs a genuine external decoding algorithm — minimum-weight perfect matching, union-find — that no static `Gate::If`/`JumpIfEqual` branch table can express. That's real, separate follow-on work, not attempted here.

### Verification
305/305 tests passing, verified against the real `sirraya-qutub` dependency (not asserted algebraically). Notable: exhaustive correction checks (every single-qubit error location, both codes) via real `DensityMatrix::fidelity`, plus two "honest limit" tests that required correcting my own initial assumptions:
- A single physical `X` error on the phase-flip code (or `Z` on the bit-flip code) isn't generic corruption — it's mathematically identical to the code's own logical `Z` operator (`H·Z·H = X`). Tests check this exact prediction, not a fidelity threshold.
- Two simultaneous errors that alias to a different single-error syndrome produce a coherent net logical `X` flip, not noise — confirmed against a non-`X`-eigenstate test vector after an earlier test using `|+⟩` masked the effect.

### What this enables
- The first real, checkable use of `Gate::If`'s multi-bit AND semantics for its intended purpose (syndrome decoding).
- A concrete, modular slot for adding more codes later (Shor 9-qubit, Steane, or — once a real decoding-algorithm integration exists — a surface code) without touching existing files.