### PR TITLE
docs: add runnable three-qubit QEC examples

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -19,5 +19,6 @@
   * [vqe_h2_ground_state](examples/vqe_h2_ground_state.md)
   * [qaoa_portfolio_optimization](examples/qaoa_portfolio_optimization.md)
   * [trotter_ising_dynamics](examples/trotter_ising_dynamics.md)
+  * [qec_three_qubit_codes](examples/qec_three_qubit_codes.md)
 * [Architecture](architecture.md)
 * [Contributing](contributing.md)

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,6 +1,6 @@
 # Examples
 
-The repository ships fifteen runnable examples in `examples/`, each with its own dedicated page below. Every one is real, working code against the actual compiler — nothing here is pseudocode or a notebook stand-in.
+The repository ships runnable examples in `examples/`, each with its own dedicated page below. Every one is real, working code against the actual compiler — nothing here is pseudocode or a notebook stand-in.
 
 Run any example with:
 
@@ -24,6 +24,7 @@ cargo run --release --example <name>
 | See a real variational algorithm, with real hardware noise and real error mitigation | [`vqe_h2_ground_state`](examples/vqe_h2_ground_state.md) or [`qaoa_portfolio_optimization`](examples/qaoa_portfolio_optimization.md) |
 | See a physics simulation benchmarked against an independent classical reference | [`trotter_ising_dynamics`](examples/trotter_ising_dynamics.md) |
 | See a communication protocol verified two independent ways, with no-cloning/no-signaling checked numerically | [`quantum_teleportation`](examples/quantum_teleportation.md) |
+| Learn how syndrome measurements drive conditional quantum error correction | [`qec_three_qubit_codes`](examples/qec_three_qubit_codes.md) |
 
 ---
 
@@ -114,6 +115,10 @@ Trotterized time evolution of a transverse-field Ising chain — the same experi
 ### [`quantum_teleportation`](examples/quantum_teleportation.md)
 
 Quantum teleportation (Bennett, Brassard, Crépeau, Jozsa, Peres & Wootters, 1993) run through the real routing/lowering/fidelity-estimation pipeline, with the classically-conditioned correction applied directly against the simulator register. Verified against the simulator's own density-matrix machinery, cross-checked by an independent Bloch-vector calculation, across six input states — with no-cloning and no-signaling checked numerically via per-outcome fidelity and outcome-independence statistics, not just asserted.
+
+### [`qec_three_qubit_codes`](examples/qec_three_qubit_codes.md)
+
+Runs the bit-flip and phase-flip repetition codes through their shared `StabilizerCode` interface: encode a logical qubit, inject one physical error, measure the syndrome, apply the matching `Gate::If` correction, decode, and verify perfect logical-state recovery.
 
 ---
 

--- a/docs/examples/qec_three_qubit_codes.md
+++ b/docs/examples/qec_three_qubit_codes.md
@@ -1,0 +1,31 @@
+# qec_three_qubit_codes
+
+A complete encode → error → syndrome → conditional correction → decode round for both three-qubit repetition codes.
+
+```bash
+cargo run --example qec_three_qubit_codes
+```
+
+## What it demonstrates
+
+The example prepares logical `|1⟩`, encodes it into three physical data qubits, and injects an error on the middle qubit:
+
+- `ThreeQubitBitFlipCode` receives `Gate::X(1)`.
+- `ThreeQubitPhaseFlipCode` receives `Gate::Z(1)`.
+
+Each code uses the `StabilizerCode` interface to measure two stabilizers into classical bits. A middle-qubit error produces syndrome `[1, 1]`. `correct()` appends three `Gate::If` branches, one for each non-zero syndrome; the simulator executes only the branch whose two classical conditions match the measured syndrome.
+
+The example then calls `decode()` and verifies the recovered logical qubit against an independently prepared `|1⟩` density matrix. It exits with an error unless the syndrome is `[1, 1]` and recovery fidelity is `1.0` within numerical tolerance.
+
+## Why the correction gates are conditional
+
+Syndrome extraction diagnoses an error without directly measuring the encoded logical state. The classical result decides which physical correction is safe:
+
+| Syndrome | Corrected data qubit |
+|---|---|
+| `[1, 0]` | q0 |
+| `[1, 1]` | q1 |
+| `[0, 1]` | q2 |
+| `[0, 0]` | none |
+
+The example prints the actual `Gate::If` table emitted by each code so the classical feed-forward step remains visible even though it is constructed through the shared trait.

--- a/examples/qec_three_qubit_codes.rs
+++ b/examples/qec_three_qubit_codes.rs
@@ -1,0 +1,89 @@
+//! Run one complete correction round with each three-qubit repetition code.
+//!
+//! Run with: `cargo run --example qec_three_qubit_codes`
+
+use sirraya_qutub::core::QuantumRegister;
+use sirraya_qutub_transpiler::ir::{Circuit, Gate};
+use sirraya_qutub_transpiler::qec::bit_flip::ThreeQubitBitFlipCode;
+use sirraya_qutub_transpiler::qec::phase_flip::ThreeQubitPhaseFlipCode;
+use sirraya_qutub_transpiler::qec::StabilizerCode;
+use sirraya_qutub_transpiler::{decompose, emit, optimize_ir};
+
+const DATA_QUBITS: [usize; 3] = [0, 1, 2];
+const ANCILLA_QUBITS: [usize; 2] = [3, 4];
+const SYNDROME_CLBITS: [usize; 2] = [0, 1];
+
+fn run_round(code: &dyn StabilizerCode, injected_error: Gate) -> Result<(), String> {
+    let mut circuit = Circuit::new(DATA_QUBITS.len() + ANCILLA_QUBITS.len());
+    circuit.num_clbits = SYNDROME_CLBITS.len();
+
+    // Prepare logical |1>, encode it across q0..q2, then corrupt the middle
+    // physical qubit. Both codes map a q1 error to syndrome bits (1, 1).
+    circuit.push(Gate::X(DATA_QUBITS[0]));
+    code.encode(&mut circuit, &DATA_QUBITS);
+    circuit.push(injected_error.clone());
+    code.extract_syndrome(
+        &mut circuit,
+        &DATA_QUBITS,
+        &ANCILLA_QUBITS,
+        &SYNDROME_CLBITS,
+    );
+
+    let correction_start = circuit.gates.len();
+    code.correct(&mut circuit, &DATA_QUBITS, &SYNDROME_CLBITS);
+    let corrections = circuit.gates[correction_start..].to_vec();
+
+    // correct() appends one Gate::If branch for each non-zero syndrome. At
+    // runtime only the branch matching the measured (1, 1) syndrome executes.
+    if !corrections.iter().all(|gate| matches!(gate, Gate::If(..))) {
+        return Err(format!(
+            "{} emitted a non-conditional correction",
+            code.id()
+        ));
+    }
+
+    code.decode(&mut circuit, &DATA_QUBITS);
+
+    let native = decompose(&optimize_ir(&circuit));
+    let (register, syndrome) = emit::run_with_measurement(&native)?;
+
+    if syndrome != [1, 1] {
+        return Err(format!(
+            "{} measured unexpected syndrome {syndrome:?}",
+            code.id()
+        ));
+    }
+
+    let recovered = register
+        .to_density_matrix()?
+        .partial_trace(&[DATA_QUBITS[0]])?;
+    let mut logical_one = QuantumRegister::new(1)?;
+    logical_one.apply_pauli_x(0)?;
+    let target = logical_one.to_density_matrix()?;
+    let fidelity = recovered.fidelity(&target)?;
+
+    if (fidelity - 1.0).abs() > 1e-9 {
+        return Err(format!(
+            "{} recovered logical |1> with fidelity {fidelity}",
+            code.id()
+        ));
+    }
+
+    println!("{}", code.id());
+    println!("  injected error: {injected_error:?}");
+    println!("  measured syndrome: {syndrome:?}");
+    println!("  conditional correction table:");
+    for correction in corrections {
+        println!("    {correction:?}");
+    }
+    println!("  recovered logical |1> fidelity: {fidelity:.6}\n");
+
+    Ok(())
+}
+
+fn main() -> Result<(), String> {
+    run_round(&ThreeQubitBitFlipCode, Gate::X(DATA_QUBITS[1]))?;
+    run_round(&ThreeQubitPhaseFlipCode, Gate::Z(DATA_QUBITS[1]))?;
+
+    Ok(())
+}

--- a/examples/qec_three_qubit_codes.rs
+++ b/examples/qec_three_qubit_codes.rs
@@ -13,7 +13,11 @@ const DATA_QUBITS: [usize; 3] = [0, 1, 2];
 const ANCILLA_QUBITS: [usize; 2] = [3, 4];
 const SYNDROME_CLBITS: [usize; 2] = [0, 1];
 
-fn run_round(code: &dyn StabilizerCode, injected_error: Gate) -> Result<(), String> {
+fn run_round(
+    code: &dyn StabilizerCode,
+    injected_error: Gate,
+    expected_syndrome: [u8; 2],
+) -> Result<(), String> {
     let mut circuit = Circuit::new(DATA_QUBITS.len() + ANCILLA_QUBITS.len());
     circuit.num_clbits = SYNDROME_CLBITS.len();
 
@@ -31,11 +35,14 @@ fn run_round(code: &dyn StabilizerCode, injected_error: Gate) -> Result<(), Stri
 
     let correction_start = circuit.gates.len();
     code.correct(&mut circuit, &DATA_QUBITS, &SYNDROME_CLBITS);
-    let corrections = circuit.gates[correction_start..].to_vec();
+    let correction_end = circuit.gates.len();
 
     // correct() appends one Gate::If branch for each non-zero syndrome. At
     // runtime only the branch matching the measured (1, 1) syndrome executes.
-    if !corrections.iter().all(|gate| matches!(gate, Gate::If(..))) {
+    if !circuit.gates[correction_start..correction_end]
+        .iter()
+        .all(|gate| matches!(gate, Gate::If(..)))
+    {
         return Err(format!(
             "{} emitted a non-conditional correction",
             code.id()
@@ -47,7 +54,7 @@ fn run_round(code: &dyn StabilizerCode, injected_error: Gate) -> Result<(), Stri
     let native = decompose(&optimize_ir(&circuit));
     let (register, syndrome) = emit::run_with_measurement(&native)?;
 
-    if syndrome != [1, 1] {
+    if syndrome != expected_syndrome {
         return Err(format!(
             "{} measured unexpected syndrome {syndrome:?}",
             code.id()
@@ -73,7 +80,7 @@ fn run_round(code: &dyn StabilizerCode, injected_error: Gate) -> Result<(), Stri
     println!("  injected error: {injected_error:?}");
     println!("  measured syndrome: {syndrome:?}");
     println!("  conditional correction table:");
-    for correction in corrections {
+    for correction in &circuit.gates[correction_start..correction_end] {
         println!("    {correction:?}");
     }
     println!("  recovered logical |1> fidelity: {fidelity:.6}\n");
@@ -82,8 +89,8 @@ fn run_round(code: &dyn StabilizerCode, injected_error: Gate) -> Result<(), Stri
 }
 
 fn main() -> Result<(), String> {
-    run_round(&ThreeQubitBitFlipCode, Gate::X(DATA_QUBITS[1]))?;
-    run_round(&ThreeQubitPhaseFlipCode, Gate::Z(DATA_QUBITS[1]))?;
+    run_round(&ThreeQubitBitFlipCode, Gate::X(DATA_QUBITS[1]), [1, 1])?;
+    run_round(&ThreeQubitPhaseFlipCode, Gate::Z(DATA_QUBITS[1]), [1, 1])?;
 
     Ok(())
 }


### PR DESCRIPTION
Closes #89.

Adds one runnable example covering both three-qubit repetition codes through the shared `StabilizerCode` interface. Each round prepares logical `|1⟩`, injects a middle-qubit error, measures syndrome `[1, 1]`, applies the emitted conditional correction, decodes, and verifies fidelity `1.0`. The examples index and mdBook navigation now link to a page explaining the flow and syndrome table.

Validation:
- `cargo test -q` (324 passed, 1 ignored)
- `rustfmt --edition 2021 --check examples/qec_three_qubit_codes.rs`
- `cargo run --quiet --example qec_three_qubit_codes`

`cargo clippy --all-targets -- -D warnings` remains blocked by existing warnings in untouched files, including `src/resource_estimate.rs`, `src/native.rs`, `src/diagram.rs`, and `src/route.rs`.

Developed with AI assistance and manually validated against the repository's current test suite.
